### PR TITLE
remove hard coded FF16_hyperpar from Parameters

### DIFF
--- a/R/ff16.R
+++ b/R/ff16.R
@@ -29,8 +29,8 @@ FF16_Species <- function(s=FF16_Strategy()) {
 ##' @export
 ##' @rdname FF16
 ##' @param ... Arguments!
-FF16_Parameters <- function(...) {
-  Parameters("FF16","FF16_Env")(...)
+FF16_Parameters <- function() {
+  Parameters("FF16","FF16_Env")(hyperpar=FF16_hyperpar)
 }
 
 ##' @export

--- a/inst/RcppR6_classes.yml
+++ b/inst/RcppR6_classes.yml
@@ -444,6 +444,8 @@ Parameters:
     concrete:
       - ["FF16": "plant::FF16_Strategy", "FF16_Env": "plant::FF16_Environment"]
       # - ["FF16r": "plant::FF16r_Strategy"]
+  constructor:
+    args: [hyperpar: "SEXP"]
   # TODO: This is broken:
   # roxygen: |
   #   Strategy parameters that tune various aspects of the biological model.

--- a/inst/include/plant/parameters.h
+++ b/inst/include/plant/parameters.h
@@ -24,15 +24,14 @@ struct Parameters {
   typedef T strategy_type;
   typedef E environment_type;
 
-  Parameters()
+  Parameters(SEXP hyperpar = R_NilValue)
     : k_I(0.5),
       patch_area(1.0),
       n_patches(1),
       disturbance_mean_interval(30),
       cohort_schedule_max_time(NA_REAL),
-      // TODO : remove this coupling to FF16
-      hyperpar(util::get_from_package("FF16_hyperpar")) {
-      validate();
+      hyperpar(hyperpar) {
+        validate();
   }
 
   // Data -- public for now (see github issue #17).

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -14,7 +14,7 @@ test_that("hyperpar creation", {
 test_that("Creation & defaults", {
   for (x in names(strategy_types)) {
     s <- strategy_types[[x]]()
-    p <- Parameters(x, "FF16_Env")()
+    p <- Parameters(x, "FF16_Env")(hyperpar=FF16_hyperpar)
     expect_is(p, sprintf("Parameters<%s,FF16_Env>", x))
 
     expect_equal(length(p$strategies), 0)
@@ -25,7 +25,7 @@ test_that("Creation & defaults", {
                      n_patches=1,    # NOTE: Different to tree 0.1
                      patch_area=1.0, # NOTE: Different to tree 0.1
                      disturbance_mean_interval=30.0,
-                     hyperpar=hyperpar(x))
+                     hyperpar=FF16_hyperpar)
 
     expect_equal(p[names(expected)], expected)
     expect_equal(p$strategy_default, s)


### PR DESCRIPTION
Ok so this decouples the FF16_hyperpar from Parameters.h and moves it to ff16.R, where it makes sense to be.

I don't think its consequences are covered in any tests. What can I run to make sure this isn't breaking anything?

Closes #234 