### PR TITLE
Remove k_I from parameters

### DIFF
--- a/inst/include/plant/parameters.h
+++ b/inst/include/plant/parameters.h
@@ -25,7 +25,6 @@ struct Parameters {
   typedef E environment_type;
 
   Parameters() :
-    k_I(0.5),
     patch_area(1.0),
     n_patches(1),
     disturbance_mean_interval(30),
@@ -35,7 +34,6 @@ struct Parameters {
   }
 
   // Data -- public for now (see github issue #17).
-  double k_I;      // Light extinction coefficient
   double patch_area; // Size of the patch (m^2)
   size_t n_patches;  // Number of patches in the metacommunity
   double disturbance_mean_interval; // Disturbance interval (years)


### PR DESCRIPTION
The light extinction coefficient (k_I) has now been moved into strategies. These are the last few breadcrumbs and can now be removed.