### PR TITLE
Ignore draft PRs

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -17,9 +17,9 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+    if: github.event.pull_request.draft == false
 
     strategy:
       fail-fast: false

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -7,6 +7,7 @@ on:
       - master
       - develop
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - master
@@ -16,8 +17,8 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
+    if: github.event.pull_request.draft == false
     runs-on: ${{ matrix.config.os }}
-
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,6 +5,7 @@ on:
       - master
       - develop
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - master
@@ -14,6 +15,7 @@ name: bench
 
 jobs:
   lint:
+    if: github.event.pull_request.draft == false
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-coverage.yml
+++ b/.github/workflows/check-coverage.yml
@@ -4,6 +4,7 @@ on:
       - main
       - master
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - master
@@ -13,6 +14,7 @@ name: test-coverage
 
 jobs:
   test-coverage:
+    if: github.event.pull_request.draft == false
     runs-on: macOS-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We can test that:

- [x] this doesn't run while in draft
- [x] does run when ready for review
- [x] doesn't run when switched back to draft

Follows: https://github.community/t/dont-run-actions-on-draft-pull-requests/16817/16