### PR TITLE
Decouple assimilation

### DIFF
--- a/inst/include/plant/control.h
+++ b/inst/include/plant/control.h
@@ -26,7 +26,6 @@ namespace plant {
 
 struct Control {
   Control();
-  void initialize();
 
   bool   plant_assimilation_adaptive;
 
@@ -73,8 +72,6 @@ struct Control {
   bool   equilibrium_solver_logN;
   bool   equilibrium_solver_try_keep;
 
-  // Things derived from this:
-  quadrature::QAG integrator;
 };
 
 inline ode::OdeControl make_ode_control(const Control& control) {

--- a/inst/include/plant/models/assimilation.h
+++ b/inst/include/plant/models/assimilation.h
@@ -27,7 +27,7 @@ class Assimilation {
   //
   // NOTE: In contrast with Daniel's implementation (but following
   // Falster 2012), we do not normalise by a_y*a_bio here.
-  double assimilate(Control& control,
+  double assimilate(quadrature::QAG& integrator,
                     const E& environment,
                     double height,
                     double area_leaf,
@@ -51,16 +51,11 @@ class Assimilation {
     f = [&] (double x) -> double {
          return compute_assimilation_h(x, height, environment);
        };
-    } else {
-      f = [&] (double x) -> double {
-        return compute_assimilation_h(x, height, environment);
-      };
-    }
 
-    if (control.plant_assimilation_adaptive && reuse_intervals) {
-      A = control.integrator.integrate_with_last_intervals(f, x_min, x_max);
+    if (integrator.is_adaptive() && reuse_intervals) {
+      A = integrator.integrate_with_last_intervals(f, x_min, x_max);
     } else {
-      A = control.integrator.integrate(f, x_min, x_max);
+      A = integrator.integrate(f, x_min, x_max);
     }
 
     return area_leaf * A;

--- a/inst/include/plant/models/assimilation.h
+++ b/inst/include/plant/models/assimilation.h
@@ -33,16 +33,24 @@ class Assimilation {
                     double area_leaf,
                     bool reuse_intervals
                     ) {
-    const bool over_distribution = control.plant_assimilation_over_distribution;
-    const double x_min = 0.0, x_max = over_distribution ? 1.0 : height;
+    //const bool over_distribution = control.plant_assimilation_over_distribution;
+    const double x_min = 0.0, x_max = height; //over_distribution ? 1.0 : height;
 
     double A = 0.0;
 
     std::function<double(double)> f;
-    if (over_distribution) {
-      f = [&] (double x) -> double {
-        return compute_assimilation_p(x, height, environment);
-      };
+    // if (over_distribution) {
+    //   f = [&] (double x) -> double {
+    //     return compute_assimilation_p(x, height, environment);
+    //   };
+    // } else {
+    //   f = [&] (double x) -> double {
+    //     return compute_assimilation_h(x, height, environment);
+    //   };
+    // }
+    f = [&] (double x) -> double {
+         return compute_assimilation_h(x, height, environment);
+       };
     } else {
       f = [&] (double x) -> double {
         return compute_assimilation_h(x, height, environment);
@@ -76,10 +84,10 @@ class Assimilation {
     return assimilation_leaf(environment.get_environment_at_height(z)) * q(z, height);
   }
 
-  double compute_assimilation_p(double p, double height,
-                                const E& environment) const {
-    return assimilation_leaf(environment.get_environment_at_height(Qp(p, height)));
-  }
+  // double compute_assimilation_p(double p, double height,
+  //                               const E& environment) const {
+  //   return assimilation_leaf(environment.get_environment_at_height(Qp(p, height)));
+  // }
 
   // [Appendix S6] Per-leaf photosynthetic rate.
   // Here, `x` is openness, ranging from 0 to 1.

--- a/inst/include/plant/models/assimilation.h
+++ b/inst/include/plant/models/assimilation.h
@@ -27,12 +27,10 @@ class Assimilation {
   //
   // NOTE: In contrast with Daniel's implementation (but following
   // Falster 2012), we do not normalise by a_y*a_bio here.
-  double assimilate(quadrature::QAG& integrator,
-                    const E& environment,
+  double assimilate(const E& environment,
                     double height,
                     double area_leaf,
-                    bool reuse_intervals
-                    ) {
+                    bool reuse_intervals) {
     //const bool over_distribution = control.plant_assimilation_over_distribution;
     const double x_min = 0.0, x_max = height; //over_distribution ? 1.0 : height;
 
@@ -102,11 +100,31 @@ class Assimilation {
     return 2 * eta * (1 - tmp) * tmp / z;
   }
 
-  void initialize(double a1, double a2, double e) {
+  void initialize(double a1, double a2, double e,
+                  bool adaptive_integration=true,
+                  int integration_rule=21,
+                  int iterations=1000,
+                  double integration_tol=1e-6) {
+
+    // strategy parameters
     a_p1 = a1;
     a_p2 = a2;
     eta = e;
+
+    // set up integrator
+    if(!adaptive_integration) {
+      iterations = 1;
+    }
+
+    integrator = quadrature::QAG(integration_rule,
+                                 iterations,
+                                 integration_tol,
+                                 integration_tol);
   }
+
+  // Used for assimilation
+  quadrature::QAG integrator;
+
 
 };
 

--- a/inst/include/plant/models/ff16_strategy.h
+++ b/inst/include/plant/models/ff16_strategy.h
@@ -13,6 +13,8 @@ public:
   typedef std::shared_ptr<FF16_Strategy> ptr;
   FF16_Strategy();
 
+  // Used for assimilation
+  quadrature::QAG integrator;
   // Overrides ----------------------------------------------
 
   // update this when the length of state_names changes

--- a/inst/include/plant/models/ff16_strategy.h
+++ b/inst/include/plant/models/ff16_strategy.h
@@ -13,8 +13,6 @@ public:
   typedef std::shared_ptr<FF16_Strategy> ptr;
   FF16_Strategy();
 
-  // Used for assimilation
-  quadrature::QAG integrator;
   // Overrides ----------------------------------------------
 
   // update this when the length of state_names changes

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -2,7 +2,7 @@
 
 namespace plant {
 
-Control::Control() : integrator(15, 1, 0, 0) {
+Control::Control() {
   plant_assimilation_adaptive = true;
 
   plant_assimilation_over_distribution = false;
@@ -47,16 +47,6 @@ Control::Control() : integrator(15, 1, 0, 0) {
   equilibrium_nattempts = 5;
   equilibrium_solver_logN = true;
   equilibrium_solver_try_keep = true;
-}
-
-void Control::initialize() {
-  if (!plant_assimilation_adaptive) {
-    plant_assimilation_iterations = 1;
-  }
-  integrator = quadrature::QAG(plant_assimilation_rule,
-                               plant_assimilation_iterations,
-                               plant_assimilation_tol,
-                               plant_assimilation_tol);
 }
 
 }

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -212,7 +212,7 @@ double FF16_Strategy::net_mass_production_dt(const FF16_Environment& environment
   const double area_bark_    = area_bark(area_leaf_);
   const double mass_bark_    = mass_bark(area_bark_, height);
   const double mass_root_    = mass_root(area_leaf_);
-  const double assimilation_ = assimilator.assimilate(integrator, environment, height,
+  const double assimilation_ = assimilator.assimilate(environment, height,
                                             area_leaf_, reuse_intervals);
   const double respiration_ =
     respiration(mass_leaf_, mass_sapwood_, mass_bark_, mass_root_);
@@ -432,21 +432,14 @@ double FF16_Strategy::height_seed(void) const {
   return util::uniroot(target, h0, h1, tol, max_iterations);
 }
 
-
-
 void FF16_Strategy::prepare_strategy() {
-
   // Set up the integrator
-  int iterations = control.plant_assimilation_adaptive
-                       ? control.plant_assimilation_iterations
-                       : 1;
+  assimilator.initialize(a_p1, a_p2, eta,
+                         control.plant_assimilation_adaptive,
+                         control.plant_assimilation_rule,
+                         control.plant_assimilation_iterations,
+                         control.plant_assimilation_tol);
 
-  integrator = quadrature::QAG(control.plant_assimilation_rule, iterations,
-                               control.plant_assimilation_tol,
-                               control.plant_assimilation_tol);
-
-
-  assimilator.initialize(a_p1, a_p2, eta);
   // NOTE: this pre-computes something to save a very small amount of time
   eta_c = 1 - 2/(1 + eta) + 1/(1 + 2*eta);
   // NOTE: Also pre-computing, though less trivial

--- a/src/k93_strategy.cpp
+++ b/src/k93_strategy.cpp
@@ -148,10 +148,8 @@ double K93_Strategy::mortality_dt(double cumulative_basal_area,
   }
 }
 
-
+// useful for pre-computing expensive objects
 void K93_Strategy::prepare_strategy() {
-  // Set up the integrator
-  control.initialize();
 }
 
 K93_Strategy::ptr make_strategy_ptr(K93_Strategy s) {

--- a/src/water_strategy.cpp
+++ b/src/water_strategy.cpp
@@ -20,7 +20,7 @@ double Water_Strategy::net_mass_production_dt(const FF16_Environment& environmen
   const double area_bark_    = area_bark(area_leaf_);
   const double mass_bark_    = mass_bark(area_bark_, height);
   const double mass_root_    = mass_root(area_leaf_);
-  const double assimilation_ = assimilator.assimilate(control, environment, height,
+  const double assimilation_ = assimilator.assimilate(integrator, environment, height,
                                                       area_leaf_, reuse_intervals);
   const double respiration_ =
     respiration(mass_leaf_, mass_sapwood_, mass_bark_, mass_root_);

--- a/src/water_strategy.cpp
+++ b/src/water_strategy.cpp
@@ -20,7 +20,7 @@ double Water_Strategy::net_mass_production_dt(const FF16_Environment& environmen
   const double area_bark_    = area_bark(area_leaf_);
   const double mass_bark_    = mass_bark(area_bark_, height);
   const double mass_root_    = mass_root(area_leaf_);
-  const double assimilation_ = assimilator.assimilate(integrator, environment, height,
+  const double assimilation_ = assimilator.assimilate(environment, height,
                                                       area_leaf_, reuse_intervals);
   const double respiration_ =
     respiration(mass_leaf_, mass_sapwood_, mass_bark_, mass_root_);


### PR DESCRIPTION
I took this one step further and moved the integrator into assimilator which is initialised per strategy anyway. This sets up a future where Control objects can be decoupled from strategies.

Let's check the benchmarks and verify there are no slowdowns. We can roll back a single commit to keep the integrator as part of FF16_Strategy.