### PR TITLE
Refactor control

### DIFF
--- a/R/build_schedule.R
+++ b/R/build_schedule.R
@@ -8,23 +8,24 @@
 ##'
 ##' @title Build Cohort Schedule
 ##' @param p Parameters object
+##' @param ctrl Control object
 ##' @return A Parameters object, with schedule components set.  The
 ##' output offspring produced is also available as an attribute
 ##' \code{birth_rate}.
 ##' @author Rich FitzJohn
 ##' @export
-build_schedule <- function(p) {
+build_schedule <- function(p, ctrl = scm_base_control()) {
   p <- validate(p)
 
   n_spp <- length(p$strategies)
   if (n_spp == 0L || !any(p$is_resident)) {
     stop("Can't build a schedule with no residents")
   }
-  control <- p$control
-  eps <- control$schedule_eps
 
-  for (i in seq_len(control$schedule_nsteps)) {
-    res <- run_scm_error(p)
+  eps <- ctrl$schedule_eps
+
+  for (i in seq_len(ctrl$schedule_nsteps)) {
+    res <- run_scm_error(p, ctrl)
     net_reproduction_ratios <- res[["net_reproduction_ratios"]]
     split <- lapply(res$err$total, function(x) x > eps)
 

--- a/R/ff16.R
+++ b/R/ff16.R
@@ -63,21 +63,21 @@ FF16_StochasticPatchRunner <- function(p) {
 ## Helper:
 ##' @export
 ##' @rdname FF16_Environment
-##' @param p A Parameters object
-FF16_make_environment <- function(p) {
-  FF16_Environment(p$control)
+##' @param ctrl Control object
+FF16_make_environment <- function(ctrl = scm_base_control()) {
+  FF16_Environment(ctrl)
 }
 
 ##' Construct a fixed environment for FF16 strategy
 ##'
 ##' @param e Value of environment (deafult  = 1.0)
-##' @param p A Parameters object
+##' @param ctrl Control object
 ##' @param height_max = 150.0 maximum possible height in environment
 ##' @rdname FF16_Environment
 ##'
 ##' @export
-FF16_fixed_environment <- function(e=1.0, p = FF16_Parameters(), height_max = 150.0) {
-  env <- FF16_make_environment(p)
+FF16_fixed_environment <- function(e=1.0, ctrl = scm_base_control(), height_max = 150.0) {
+  env <- FF16_make_environment(ctrl)
   env$set_fixed_environment(e, height_max)
   env
 }
@@ -107,12 +107,7 @@ FF16_test_environment <- function(height, n=101, light_env=NULL,
   interpolator <- Interpolator()
   interpolator$init(hh, ee)
 
-  parameters <- FF16_Parameters()
-  parameters$strategies <- rep(list(FF16_Strategy()), n_strategies)
-
-  parameters$is_resident <- rep(TRUE, n_strategies)
-
-  ret <- FF16_make_environment(parameters)
+  ret <- FF16_make_environment()
   ret$canopy$canopy_interpolator <- interpolator
   attr(ret, "light_env") <- light_env
   ret

--- a/R/ff16r.R
+++ b/R/ff16r.R
@@ -64,9 +64,9 @@ FF16r_StochasticPatchRunner <- function(p) {
 ## Helper:
 ##' @export
 ##' @rdname FF16_Environment
-##' @param p A Parameters object
-FF16r_make_environment <- function(p) {
-  FF16_Environment(p$control)
+##' @param ctrl Control object
+FF16r_make_environment <- function(ctrl = scm_base_control()) {
+  FF16_Environment(ctrl)
 }
 
 ##' This makes a pretend light environment over the plant height,
@@ -93,12 +93,7 @@ FF16r_test_environment <- function(height, n=101, light_env=NULL,
   interpolator <- Interpolator()
   interpolator$init(hh, ee)
 
-  parameters <- FF16r_Parameters()
-  parameters$strategies <- rep(list(FF16r_Strategy()), n_strategies)
-
-  parameters$is_resident <- rep(TRUE, n_strategies)
-
-  ret <- FF16r_make_environment(parameters)
+  ret <- FF16r_make_environment()
   ret$canopy$canopy_interpolator <- interpolator
   attr(ret, "light_env") <- light_env
   ret

--- a/R/k93.R
+++ b/R/k93.R
@@ -69,21 +69,21 @@ K93_StochasticPatchRunner <- function(p) {
 ## Helper:
 ##' @export
 ##' @rdname K93_Environment
-##' @param p A Parameters object
-K93_make_environment <- function(p) {
-  K93_Environment(p$control)
+##' @param ctrl Control object
+K93_make_environment <- function(ctrl = scm_base_control()) {
+  K93_Environment(ctrl)
 }
 
 ##' Construct a fixed environment for K93 strategy
 ##'
 ##' @param e Value of environment (default=1.0)
-##' @param p A Parameters object
+##' @param ctrl Control object
 ##' @param height_max = 150.0 maximum possible height in environment
 ##' @rdname K93_Environment
 ##'
 ##' @export
-K93_fixed_environment <- function(e=1.0, p = K93_Parameters(), height_max = 300.0) {
-  env <- K93_make_environment(p)
+K93_fixed_environment <- function(e=1.0, ctrl = scm_base_control(), height_max = 300.0) {
+  env <- K93_make_environment(ctrl)
   env$set_fixed_environment(e, height_max)
   env
 }
@@ -115,12 +115,12 @@ K93_test_environment <- function(height, n=101, light_env=NULL,
   interpolator <- Interpolator()
   interpolator$init(hh, ee)
 
-  parameters <- K93_Parameters()
-  parameters$strategies <- rep(list(K93_Strategy()), n_strategies)
+  # parameters <- K93_Parameters()
+  # parameters$strategies <- rep(list(K93_Strategy()), n_strategies)
+  # 
+  # parameters$is_resident <- rep(TRUE, n_strategies)
 
-  parameters$is_resident <- rep(TRUE, n_strategies)
-
-  ret <- K93_make_environment(parameters)
+  ret <- K93_make_environment()
   ret$canopy$canopy_interpolator <- interpolator
   attr(ret, "light_env") <- light_env
   ret

--- a/R/scm_support.R
+++ b/R/scm_support.R
@@ -43,25 +43,6 @@ equilibrium_quiet <- function(base=Control()) {
   base
 }
 
-##' Run the SCM, returning the SCM object for interrogation
-##'
-##' This is the simplest way of using the SCM, probably.
-##' @title Run SCM
-##' @param p Parameters object
-##' @param use_ode_times Should ODE times be used?
-##' @return A \code{SCM} object.
-##' @author Rich FitzJohn
-##' @export
-run_scm <- function(p, use_ode_times=FALSE) {
-  types <- extract_RcppR6_template_types(p, "Parameters")
-  scm <- do.call('SCM', types)(p)
-  if (use_ode_times) {
-    scm$use_ode_times <- TRUE
-  }
-  scm$run()
-  scm
-}
-
 ##' Hopefully sensible set of parameters for use with the SCM.  Turns
 ##' accuracy down a bunch, makes it noisy, sets up the
 ##' hyperparameterisation that we most often use.
@@ -69,12 +50,41 @@ run_scm <- function(p, use_ode_times=FALSE) {
 ##' @author Rich FitzJohn
 ##' @param type Name of model (defaults to FF16 but any strategy name is valid).
 ##' @export
-scm_base_parameters <- function(type="FF16", env=environment_type(type)) {
+scm_base_control <- function(type="FF16", env=environment_type(type)) {
   ctrl <- equilibrium_verbose(fast_control())
   ctrl$schedule_eps <- 0.005
   ctrl$equilibrium_eps <- 1e-3
-  Parameters(type, env)(patch_area=1.0, control=ctrl)
+  return(ctrl)
 }
+
+
+##' This used to be bundled into base control but refactoring to separate
+##' concerns. May disappear in the future.
+scm_base_parameters <- function(type="FF16", env=environment_type(type)) {
+   Parameters(type, env)(patch_area=1.0)
+}
+
+
+##' Run the SCM, returning the SCM object for interrogation
+##'
+##' This is the simplest way of using the SCM, probably.
+##' @title Run SCM
+##' @param p Parameters object
+##' @param ctrl Control object
+##' @param use_ode_times Should ODE times be used?
+##' @return A \code{SCM} object.
+##' @author Rich FitzJohn
+##' @export
+run_scm <- function(p, ctrl, use_ode_times=FALSE) {
+  types <- extract_RcppR6_template_types(p, "Parameters")
+  scm <- do.call('SCM', types)(p, ctrl)
+  if (use_ode_times) {
+    scm$use_ode_times <- TRUE
+  }
+  scm$run()
+  scm
+}
+
 
 ##' Run the SCM model, given a Parameters and CohortSchedule
 ##'
@@ -84,11 +94,12 @@ scm_base_parameters <- function(type="FF16", env=environment_type(type)) {
 ##'
 ##' @title Run the SCM, Collecting Output
 ##' @param p A \code{Parameters} object
+##' @param ctrl Control object
 ##' @param include_competition_effect Include total leaf area (will change; see
 ##' issue #138)
 ##' @author Rich FitzJohn
 ##' @export
-run_scm_collect <- function(p, include_competition_effect=FALSE) {
+run_scm_collect <- function(p, ctrl, include_competition_effect=FALSE) {
   collect_default <- function(scm) {
     scm$state
   }
@@ -107,7 +118,7 @@ run_scm_collect <- function(p, include_competition_effect=FALSE) {
   collect <- if (include_competition_effect) collect_competition_effect else collect_default
   types <- extract_RcppR6_template_types(p, "Parameters")
 
-  scm <- do.call('SCM', types)(p)
+  scm <- do.call('SCM', types)(p, ctrl)
   res <- list(collect(scm))
 
   while (!scm$complete) {
@@ -151,11 +162,12 @@ run_scm_collect <- function(p, include_competition_effect=FALSE) {
 ##' @title Reconstruct a patch
 ##' @param state State object created by \code{scm_state}
 ##' @param p Parameters object
+##' @param ctrl Control object
 ##' @export
-make_patch <- function(state, p) {
+make_patch <- function(state, p, ctrl = scm_base_control()) {
   types <- extract_RcppR6_template_types(p, "Parameters")
   n <- viapply(state$species, ncol)
-  patch <- do.call('Patch', types)(p)
+  patch <- do.call('Patch', types)(p, ctrl)
   patch$set_state(state$time, unlist(state$species), n, state$env)
   patch
 }
@@ -179,9 +191,9 @@ scm_patch <- function(i, x) {
   make_patch(scm_state(i, x), x$p)
 }
 
-run_scm_error <- function(p) {
+run_scm_error <- function(p, ctrl) {
   types <- extract_RcppR6_template_types(p, "Parameters")
-  scm <- do.call('SCM', types)(p)
+  scm <- do.call('SCM', types)(p, ctrl)
   n_spp <- length(p$strategies)
 
   lai_error <- rep(list(NULL), n_spp)
@@ -212,16 +224,20 @@ run_scm_error <- function(p) {
 ##' @param ... Named set of parameters
 ##' @param pars A list of parameters
 ##' @param base_parameters_fn Function for creating base parameter set (default scm_base_parameters)
+##' @param base_control_fn Function for creating base Control object (default scm_base_control)
 ##' @param make_hyperpar_fn Function for creating hyperparameterisation (default make_FF16_hyperpar)
 ##' @export
-assembly_parameters <- function(..., pars=NULL, base_parameters_fn = scm_base_parameters,
+assembly_parameters <- function(..., pars=NULL, 
+                                base_parameters_fn = scm_base_parameters,
+                                base_control_fn = scm_base_control,
                                 make_hyperpar_fn = make_FF16_hyperpar) {
 
   p <- base_parameters_fn()
+  ctrl <- base_control_fn()
 
   ## These are nice to have:
-  p$control$equilibrium_solver_name <- "hybrid"
-  p$control$equilibrium_nsteps <- 60
+  ctrl$equilibrium_solver_name <- "hybrid"
+  ctrl$equilibrium_nsteps <- 60
 
   if (is.null(pars)) {
     pars <- list(...)
@@ -232,10 +248,9 @@ assembly_parameters <- function(..., pars=NULL, base_parameters_fn = scm_base_pa
   if (length(pars) > 0L) {
     assert_named_if_not_empty(pars)
 
-    excl <- c("control", "strategy_default", "hyperpar")
+    excl <- c("strategy_default", "hyperpar")
     pos <- setdiff(c(names(formals(make_hyperpar_fn)),
                      names(p),
-                     names(p$control),
                      names(p$strategy_default)),
                    excl)
     unk <- setdiff(names(pars), pos)
@@ -245,7 +260,6 @@ assembly_parameters <- function(..., pars=NULL, base_parameters_fn = scm_base_pa
 
     nms_hyper <- intersect(names(pars), names(formals(make_hyperpar_fn)))
     p                  <- modify_list(p,                  pars)
-    p$control          <- modify_list(p$control,          pars)
     p$strategy_default <- modify_list(p$strategy_default, pars)
   }
   p

--- a/R/scm_support.R
+++ b/R/scm_support.R
@@ -6,13 +6,12 @@
 ##' @param base An optional \code{Control} object.  If omitted, the
 ##' defaults are used.
 fast_control <- function(base=Control()) {
-  base$environment_rescale_usually <- TRUE
-  base$environment_light_tol <- 1e-4
+  base$canopy_rescale_usually <- TRUE
+  base$canopy_light_tol <- 1e-4
 
-  base$plant_assimilation_adaptive <- FALSE
-  base$plant_assimilation_rule <- 21
-  base$plant_assimilation_over_distribution <- FALSE
-  base$plant_assimilation_tol <- 1e-4
+  base$assimilator_adaptive_integration <- FALSE
+  base$assimilator_integration_rule <- 21
+  base$assimilator_integration_tol <- 1e-4
 
   base$ode_tol_rel <- 1e-4
   base$ode_tol_abs <- 1e-4

--- a/R/stochastic.R
+++ b/R/stochastic.R
@@ -42,16 +42,18 @@ stochastic_schedule <- function(p) {
 ##'
 ##' @title Run a stochastic patch, Collecting Output
 ##' @param p A \code{\link{FF16_Parameters}} object
+##' @param ctrl Control object
 ##' @param random_schedule setting to TRUE causes algorithm to generate
 ##' a random schedule based on offspring arrival and area.
 ##' @author Rich FitzJohn
 ##' @export
-run_stochastic_collect <- function(p, random_schedule=TRUE) {
+run_stochastic_collect <- function(p, ctrl = scm_base_control(), 
+                                   random_schedule=TRUE) {
   collect <- function(obj) {
     obj$state
   }
   types <- extract_RcppR6_template_types(p, "Parameters")
-  obj <- do.call('StochasticPatchRunner', types)(p)
+  obj <- do.call('StochasticPatchRunner', types)(p, ctrl)
   if (random_schedule) {
     obj$schedule <- stochastic_schedule(p)
   }

--- a/R/water.R
+++ b/R/water.R
@@ -64,21 +64,21 @@ Water_StochasticPatchRunner <- function(p) {
 ## Helper:
 ##' @export
 ##' @rdname FF16_Environment
-##' @param p A Parameters object
-Water_make_environment <- function(p) {
-  FF16_Environment(p$control)
+##' @param ctrl Control object
+Water_make_environment <- function(ctrl = scm_base_control()) {
+  FF16_Environment(ctrl)
 }
 
 ##' Construct a fixed environment for Water strategy
 ##'
 ##' @param e Value of environment (deafult  = 1.0)
-##' @param p A Parameters object
+##' @param ctrl Control object
 ##' @param height_max = 150.0 maximum possible height in environment
 ##' @rdname FF16_Environment
 ##'
 ##' @export
-Water_fixed_environment <- function(e=1.0, p = Water_Parameters(), height_max = 150.0) {
-  env <- Water_make_environment(p)
+Water_fixed_environment <- function(e=1.0, ctrl = scm_base_control(), height_max = 150.0) {
+  env <- Water_make_environment(ctrl)
   env$set_fixed_environment(e, height_max)
   env
 }
@@ -108,12 +108,7 @@ Water_test_environment <- function(height, n=101, light_env=NULL,
   interpolator <- Interpolator()
   interpolator$init(hh, ee)
 
-  parameters <- Water_Parameters()
-  parameters$strategies <- rep(list(Water_Strategy()), n_strategies)
-
-  parameters$is_resident <- rep(TRUE, n_strategies)
-
-  ret <- Water_make_environment(parameters)
+  ret <- Water_make_environment()
   ret$canopy$canopy_interpolator <- interpolator
   attr(ret, "light_env") <- light_env
   ret

--- a/inst/RcppR6_classes.yml
+++ b/inst/RcppR6_classes.yml
@@ -105,11 +105,10 @@ Control:
     variadic arguments, or as a list, but not both).
     @export
   list:
-    - plant_assimilation_adaptive: bool
-    - plant_assimilation_over_distribution: bool
-    - plant_assimilation_tol: double
-    - plant_assimilation_iterations: size_t
-    - plant_assimilation_rule: size_t
+    - assimilator_adaptive_integration: bool
+    - assimilator_integration_tol: double
+    - assimilator_integration_iterations: size_t
+    - assimilator_integration_rule: size_t
     - plant_seed_tol: double
     - plant_seed_iterations: int
     - soil_infiltration_rate: double
@@ -118,10 +117,10 @@ Control:
     - cohort_gradient_direction: int
     - cohort_gradient_richardson: bool
     - cohort_gradient_richardson_depth: size_t
-    - environment_light_tol: double
-    - environment_light_nbase: size_t
-    - environment_light_max_depth: size_t
-    - environment_rescale_usually: bool
+    - canopy_light_tol: double
+    - canopy_light_nbase: size_t
+    - canopy_light_max_depth: size_t
+    - canopy_rescale_usually: bool
     - ode_step_size_initial: double
     - ode_step_size_min: double
     - ode_step_size_max: double

--- a/inst/RcppR6_classes.yml
+++ b/inst/RcppR6_classes.yml
@@ -363,7 +363,6 @@ Parameters:
     - strategies: "std::vector<T>"
     - birth_rate: "std::vector<double>"
     - is_resident: "std::vector<bool>"
-    - control: "plant::Control"
     - strategy_default: "T"
     - cohort_schedule_times_default: "std::vector<double>"
     - cohort_schedule_times: "std::vector<std::vector<double> >"
@@ -461,7 +460,7 @@ Patch:
       - ["FF16r": "plant::FF16r_Strategy", "FF16_Env": "plant::FF16_Environment"]
       - ["K93": "plant::K93_Strategy", "K93_Env": "plant::K93_Environment"]
   constructor:
-    args: [parameters: "plant::Parameters<T,E>"]
+    args: [parameters: "plant::Parameters<T,E>", control: "plant::Control"]
   active:
     time: {type: double, access: member}
     size: {type: size_t, access: member}
@@ -527,7 +526,7 @@ SCM:
       - ["FF16r": "plant::FF16r_Strategy", "FF16_Env": "plant::FF16_Environment"]
       - ["K93": "plant::K93_Strategy", "K93_Env": "plant::K93_Environment"]
   constructor:
-    args: [parameters: "plant::Parameters<T,E>"]
+    args: [parameters: "plant::Parameters<T,E>", control: "plant::Control"]
   methods:
     run:
       return_type: void
@@ -638,7 +637,7 @@ StochasticPatch:
       - ["FF16r": "plant::FF16r_Strategy", "FF16_Env": "plant::FF16_Environment"]
       - ["K93": "plant::K93_Strategy", "K93_Env": "plant::K93_Environment"]
   constructor:
-    args: [parameters: "plant::Parameters<T,E>"]
+    args: [parameters: "plant::Parameters<T,E>", control: "plant::Control"]
   active:
     time: {type: double, access: member}
     size: {type: size_t, access: member}
@@ -700,7 +699,7 @@ StochasticPatchRunner:
       - ["FF16r": "plant::FF16r_Strategy", "FF16_Env": "plant::FF16_Environment"]
       - ["K93": "plant::K93_Strategy", "K93_Env": "plant::K93_Environment"]
   constructor:
-    args: [parameters: "plant::Parameters<T,E>"]
+    args: [parameters: "plant::Parameters<T,E>", control: "plant::Control"]
   methods:
     run:
       return_type: void

--- a/inst/docs/demography.Rmd
+++ b/inst/docs/demography.Rmd
@@ -547,7 +547,7 @@ Starting with an initial set of 33 points, we assess how much each point
 contributes to the accuracy of the spline fit at the location of each
 cohort, first via exact calculation, and second by linearly interpolating
 from adjacent cohorts. The absolute difference in these values is
-compared to the control parameter `environment_light_tol`. If
+compared to the control parameter `canopy_light_tol`. If
 the error is greater than this tolerance, the interval is bisected and the is
 process repeated (see [adaptive_interpolator.h](https://github.com/traitecoevo/plant/blob/master/inst/include/plant/adaptive_interpolator.h) for details).
 
@@ -558,9 +558,9 @@ a plant's assimilation at each time step thus requires integrating
 leaf-level rates over the plant. The integration is performed using
 Gaussian quadrature, using the QUADPACK routines [@Piessens-1983]
 adapted from the [GNU Scientific Library](http://www.gnu.org/software/gsl/) [@Galassi-2009]; see [qag.h](https://github.com/traitecoevo/plant/blob/master/inst/include/plant/qag.h) for details.
-If the control parameter `plant_assimilation_adaptive` is `TRUE`,
+If the control parameter `assimilator_adaptive_integration` is `TRUE`,
 the integration is performed using adaptive refinement with an accuracy
-controlled by the parameter `plant_assimilation_tol`.
+controlled by the parameter `assimilator_integration_tol`.
 
 ### Solving for seed rains {#solving-demographic-seed-rain}
 

--- a/inst/include/plant/canopy.h
+++ b/inst/include/plant/canopy.h
@@ -25,10 +25,10 @@ public:
 
   Canopy(Control control) {
     canopy_generator = interpolator::AdaptiveInterpolator(
-      control.environment_light_tol,
-      control.environment_light_tol,
-      control.environment_light_nbase,
-      control.environment_light_max_depth
+      control.canopy_light_tol,
+      control.canopy_light_tol,
+      control.canopy_light_nbase,
+      control.canopy_light_max_depth
     );
     canopy_interpolator = canopy_generator.construct(
       [&](double height) {

--- a/inst/include/plant/control.h
+++ b/inst/include/plant/control.h
@@ -27,12 +27,10 @@ namespace plant {
 struct Control {
   Control();
 
-  bool   plant_assimilation_adaptive;
-
-  bool   plant_assimilation_over_distribution;
-  double plant_assimilation_tol;
-  size_t plant_assimilation_iterations;
-  size_t plant_assimilation_rule;
+  bool   assimilator_adaptive_integration;
+  double assimilator_integration_tol;
+  size_t assimilator_integration_iterations;
+  size_t assimilator_integration_rule;
 
   double plant_seed_tol;
   size_t plant_seed_iterations;
@@ -45,10 +43,10 @@ struct Control {
   bool   cohort_gradient_richardson;
   size_t cohort_gradient_richardson_depth;
 
-  double environment_light_tol;
-  size_t environment_light_nbase;
-  size_t environment_light_max_depth;
-  bool   environment_rescale_usually;
+  double canopy_light_tol;
+  size_t canopy_light_nbase;
+  size_t canopy_light_max_depth;
+  bool   canopy_rescale_usually;
 
   double ode_step_size_initial;
   double ode_step_size_min;

--- a/inst/include/plant/parameters.h
+++ b/inst/include/plant/parameters.h
@@ -46,12 +46,6 @@ struct Parameters {
   std::vector<double> birth_rate;
   std::vector<bool> is_resident;
 
-  // Algorithm control.
-  Control control;
-
-  // Templated environment
-  environment_type environment;
-
   Disturbance_Regime* disturbance;
 
   // Default strategy.
@@ -113,12 +107,6 @@ void Parameters<T,E>::validate() {
     util::stop("Incorrect length cohort_schedule_times");
   }
 
-  // Overwrite all strategy control objects so that they take the
-  // Parameters' control object.
-  for (auto& s : strategies) {
-    s.control = control;
-  }
-
   // Disturbances used to describe evolution of a metapopulation of patches
   // when calculating fitness, otherwise defaults to fixed-duration run without
   // disturbance
@@ -128,8 +116,6 @@ void Parameters<T,E>::validate() {
   else {
     disturbance = new No_Disturbance();
   }
-
-  environment = environment_type(control);
 }
 
 // Separating this out just because it's a bit crap:

--- a/inst/include/plant/patch.h
+++ b/inst/include/plant/patch.h
@@ -249,7 +249,7 @@ ode::const_iterator Patch<T,E>::set_ode_state(ode::const_iterator it,
   it = environment.set_ode_state(it);
 
   environment.time = time;
-  if (parameters.control.environment_rescale_usually) {
+  if (parameters.control.canopy_rescale_usually) {
     rescale_environment();
   } else {
     compute_environment();

--- a/inst/include/plant/scm.h
+++ b/inst/include/plant/scm.h
@@ -23,7 +23,7 @@ public:
   typedef Parameters<T,E> parameters_type;
 
 
-  SCM(parameters_type p);
+  SCM(parameters_type p, plant::Control c);
 
   void run();
   std::vector<size_t> run_next();
@@ -67,11 +67,11 @@ private:
 };
 
 template <typename T, typename E>
-SCM<T,E>::SCM(parameters_type p)
+SCM<T,E>::SCM(parameters_type p, Control c)
   : parameters(p),
-    patch(parameters),
+    patch(parameters, c),
     cohort_schedule(make_cohort_schedule(parameters)),
-    solver(patch, make_ode_control(p.control)) {
+    solver(patch, make_ode_control(c)) {
   parameters.validate();
   if (!util::identical(parameters.patch_area, 1.0)) {
     util::stop("Patch area must be exactly 1 for the SCM");

--- a/inst/include/plant/stochastic_patch.h
+++ b/inst/include/plant/stochastic_patch.h
@@ -17,10 +17,11 @@ template <typename T, typename E>
 class StochasticPatch {
 public:
   typedef T                      strategy_type;
-  typedef Individual<T,E>             individual_type;
+  typedef E                      environment_type;
+  typedef Individual<T,E>        individual_type;
   typedef StochasticSpecies<T,E> species_type;
   typedef Parameters<T,E>        parameters_type;
-  StochasticPatch(parameters_type p);
+  StochasticPatch(parameters_type p, Control c);
   void reset();
 
   size_t size() const {return species.size();}
@@ -79,15 +80,18 @@ private:
   std::vector<bool> is_resident;
   E environment;
   std::vector<species_type> species;
+  Control control;
 };
 
 template <typename T, typename E>
-StochasticPatch<T,E>::StochasticPatch(parameters_type p)
+StochasticPatch<T,E>::StochasticPatch(parameters_type p, Control c)
   : parameters(p),
+    control(c),
     is_resident(p.is_resident) {
   parameters.validate();
-  environment = p.environment;
+  environment = environment_type(control);
   for (auto s : parameters.strategies) {
+    s.control = control;
     species.push_back(species_type(s));
   }
   reset();
@@ -228,7 +232,7 @@ ode::const_iterator StochasticPatch<T,E>::set_ode_state(ode::const_iterator it,
                                                       double time) {
   it = ode::set_ode_state(species.begin(), species.end(), it);
   environment.time = time;
-  if (parameters.control.canopy_rescale_usually) {
+  if (control.canopy_rescale_usually) {
     rescale_environment();
   } else {
     compute_environment();

--- a/inst/include/plant/stochastic_patch.h
+++ b/inst/include/plant/stochastic_patch.h
@@ -228,7 +228,7 @@ ode::const_iterator StochasticPatch<T,E>::set_ode_state(ode::const_iterator it,
                                                       double time) {
   it = ode::set_ode_state(species.begin(), species.end(), it);
   environment.time = time;
-  if (parameters.control.environment_rescale_usually) {
+  if (parameters.control.canopy_rescale_usually) {
     rescale_environment();
   } else {
     compute_environment();

--- a/inst/include/plant/stochastic_patch_runner.h
+++ b/inst/include/plant/stochastic_patch_runner.h
@@ -28,7 +28,7 @@ public:
   typedef StochasticPatch<T,E>   patch_type;
   typedef Parameters<T,E>        parameters_type;
 
-  StochasticPatchRunner(parameters_type p);
+  StochasticPatchRunner(parameters_type p, Control c);
 
   void run();
   size_t run_next();
@@ -57,11 +57,11 @@ private:
 };
 
 template <typename T, typename E>
-StochasticPatchRunner<T,E>::StochasticPatchRunner(parameters_type p)
+StochasticPatchRunner<T,E>::StochasticPatchRunner(parameters_type p, Control c)
   : parameters(p),
-    patch(parameters),
+    patch(parameters, c),
     schedule(make_empty_stochastic_schedule(parameters)),
-    solver(patch, make_ode_control(p.control)) {
+    solver(patch, make_ode_control(c)) {
   parameters.validate();
 }
 

--- a/scripts/carrying_capacity.R
+++ b/scripts/carrying_capacity.R
@@ -1,6 +1,6 @@
 plant_log_console()
 p <- scm_base_parameters()
-p$control <- equilibrium_quiet(p$control)
+ctrl <- equilibrium_quiet(Control())
 
 ## Find the viable range for lma for the default parameters:
 r <- viable_fitness(bounds(lma=c(1e-5, 1e3)), p)

--- a/scripts/equilibrium.R
+++ b/scripts/equilibrium.R
@@ -1,23 +1,24 @@
 ## Find the equilibrium offspring arrival a few different ways:
 plant_log_console()
+ctrl <- scm_base_control()
 p <- scm_base_parameters()
 p$strategies <- list(FF16_Strategy())
 p$birth_rate <- 1.1
 
-p$control$equilibrium_solver_name <- "iteration"
-ans <- equilibrium_birth_rate(p)
+ctrl$equilibrium_solver_name <- "iteration"
+ans <- equilibrium_birth_rate(p, ctrl)
 ans$birth_rate
 
-p$control$equilibrium_solver_name <- "nleqslv"
-ans <- equilibrium_birth_rate(p)
+ctrl$equilibrium_solver_name <- "nleqslv"
+ans <- equilibrium_birth_rate(p, ctrl)
 ans$birth_rate
 
-p$control$equilibrium_solver_name <- "dfsane"
-ans <- equilibrium_birth_rate(p)
+ctrl$equilibrium_solver_name <- "dfsane"
+ans <- equilibrium_birth_rate(p, ctrl)
 ans$birth_rate
 
-p$control$equilibrium_solver_name <- "hybrid"
-ans <- equilibrium_birth_rate(p)
+ctrl$equilibrium_solver_name <- "hybrid"
+ans <- equilibrium_birth_rate(p, ctrl)
 ans$birth_rate
 
 bounds <- viable_fitness(bounds(lma=c(0.01, 10.0)), p)

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -3,12 +3,10 @@
 namespace plant {
 
 Control::Control() {
-  plant_assimilation_adaptive = true;
-
-  plant_assimilation_over_distribution = false;
-  plant_assimilation_tol = 1e-6;
-  plant_assimilation_iterations = 1000;
-  plant_assimilation_rule = 21;
+  assimilator_adaptive_integration = true;
+  assimilator_integration_tol = 1e-6;
+  assimilator_integration_iterations = 1000;
+  assimilator_integration_rule = 21;
 
   plant_seed_tol = 1e-8;
   plant_seed_iterations = 1000;
@@ -21,10 +19,10 @@ Control::Control() {
   cohort_gradient_richardson = false;
   cohort_gradient_richardson_depth = 4;
 
-  environment_light_tol = 1e-6;
-  environment_light_nbase = 17;
-  environment_light_max_depth = 16;
-  environment_rescale_usually = false;
+  canopy_light_tol = 1e-6;
+  canopy_light_nbase = 17;
+  canopy_light_max_depth = 16;
+  canopy_rescale_usually = false;
 
   ode_step_size_initial = 1e-6;
   ode_step_size_min = 1e-6;

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -435,10 +435,10 @@ double FF16_Strategy::height_seed(void) const {
 void FF16_Strategy::prepare_strategy() {
   // Set up the integrator
   assimilator.initialize(a_p1, a_p2, eta,
-                         control.plant_assimilation_adaptive,
-                         control.plant_assimilation_rule,
-                         control.plant_assimilation_iterations,
-                         control.plant_assimilation_tol);
+                         control.assimilator_adaptive_integration,
+                         control.assimilator_integration_rule,
+                         control.assimilator_integration_iterations,
+                         control.assimilator_integration_tol);
 
   // NOTE: this pre-computes something to save a very small amount of time
   eta_c = 1 - 2/(1 + eta) + 1/(1 + 2*eta);

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -6,12 +6,12 @@ test_that("Defaults", {
     cohort_gradient_direction = 1L,
     cohort_gradient_richardson = FALSE,
     cohort_gradient_richardson_depth = 4, # size_t, so not int
-    
-    environment_light_max_depth= 16, # size_t
-    environment_light_nbase = 17, # size_t
-    environment_light_tol = 1e-6,
-    environment_rescale_usually = FALSE,
-    
+
+    canopy_light_max_depth= 16, # size_t
+    canopy_light_nbase = 17, # size_t
+    canopy_light_tol = 1e-6,
+    canopy_rescale_usually = FALSE,
+
     ode_a_dydt = 0.0,
     ode_a_y = 1.0,
     ode_step_size_initial = 1e-6,
@@ -19,19 +19,18 @@ test_that("Defaults", {
     ode_step_size_min = 1e-6,
     ode_tol_abs = 1e-6,
     ode_tol_rel = 1e-6,
-    
-    plant_assimilation_adaptive = TRUE,
-    plant_assimilation_iterations = 1000, # size_t so not int
-    plant_assimilation_rule = 21, # size_t so not int
-    plant_assimilation_over_distribution = FALSE,
-    plant_assimilation_tol = 1e-6,
-    
+
+    assimilator_adaptive_integration = TRUE,
+    assimilator_integration_iterations = 1000, # size_t so not int
+    assimilator_integration_rule = 21, # size_t so not int
+    assimilator_integration_tol = 1e-6,
+
     plant_seed_iterations = 1000, # size_t
     plant_seed_tol = 1e-8, # 1e-6, Had to change this...
-    
+
     soil_infiltration_rate = 0.0,
     soil_number_of_depths = 0,
-    
+
     schedule_nsteps   = 20, # size_t
     schedule_eps      = 1e-3,
     schedule_verbose  = FALSE,

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -9,7 +9,7 @@ for (x in names(strategy_types)) {
 
   test_that("Empty environment", {
     p <- Parameters(x, e)()
-    env <- make_environment(x, p)
+    env <- make_environment(x)
 
     ## At this point, we should have full canopy openness, partly because
     ## the spline is just not constructed.
@@ -22,7 +22,7 @@ for (x in names(strategy_types)) {
   })
 
   test_that("Manually set environment", {
-    env <- make_environment(x, Parameters(x, e)())
+    env <- make_environment(x)
     ## Now, set the light environment.
     hh <- seq(0, 10, length.out=101)
     light_env <- function(x) {

--- a/tests/testthat/test-modular.R
+++ b/tests/testthat/test-modular.R
@@ -39,12 +39,13 @@ test_that("Construction", {
     expect_is(par, sprintf("Parameters<%s,%s>", x, e))
     expect_equal(par$strategies[[1]], s)
 
-    pat <- Patch(x, e)(par)
+    ctrl <- Control()
+    pat <- Patch(x, e)(par, ctrl)
     expect_is(pat, "Patch")
     expect_is(pat, sprintf("Patch<%s,%s>", x, e))
     expect_equal(class(pat$species[[1]]), class(sp))
 
-    scm <- SCM(x, e)(par)
+    scm <- SCM(x, e)(par, ctrl)
     expect_is(scm, "SCM")
     expect_is(scm, sprintf("SCM<%s,%s>", x, e))
     expect_equal(class(scm$patch), class(pat))
@@ -55,12 +56,12 @@ test_that("Construction", {
     expect_is(s_sp, sprintf("StochasticSpecies<%s,%s>", x, e))
     expect_equal(class(s_sp$new_cohort), class(p))
 
-    s_pat <- StochasticPatch(x, e)(par)
+    s_pat <- StochasticPatch(x, e)(par, ctrl)
     expect_is(s_pat, "StochasticPatch")
     expect_is(s_pat, sprintf("StochasticPatch<%s,%s>", x, e))
     expect_equal(class(s_pat$species[[1]]), class(s_sp))
 
-    s_pr <- StochasticPatchRunner(x, e)(par)
+    s_pr <- StochasticPatchRunner(x, e)(par, ctrl)
     expect_is(s_pr, "StochasticPatchRunner")
     expect_is(s_pr, sprintf("StochasticPatchRunner<%s,%s>", x, e))
     expect_equal(class(s_pr$patch), class(s_pat))

--- a/tests/testthat/test-parameters.R
+++ b/tests/testthat/test-parameters.R
@@ -67,37 +67,38 @@ test_that("Nontrivial creation", {
   }
 })
 
-test_that("Parameters overwrites Strategy control", {
-  for (x in names(strategy_types)) {
-    ctrl <- ctrl_s <- ctrl_p <- Control()
-    ## set these just as markers:
-    ctrl_s$schedule_eps <- 1
-    ctrl_p$schedule_eps <- 2
-
-    s <- strategy_types[[x]](control=ctrl_s)
-    e <- environment_types[[x]]
-    expect_identical(s$control, ctrl_s)
-    expect_false(identical(s$control, ctrl_p))
-
-    p <- Parameters(x, e)(control=ctrl_p)
-    expect_false(identical(p$control, ctrl_s))
-    expect_identical(p$control, ctrl_p)
-
-    p$strategies <- list(s)
-    p$birth_rate <- 1
-    p$is_resident <- TRUE
-    ## Pass though to force validation:
-    tmp <- Patch(x, e)(p)$parameters
-    expect_identical(tmp$control, ctrl_p)
-    expect_identical(tmp$strategies[[1]]$control, ctrl_p)
-
-    ## In one shot:
-    p2 <- Parameters(x, e)(control=ctrl_p, strategies=list(s),
-                           birth_rate=1, is_resident=TRUE)
-    expect_identical(p2$control, ctrl_p)
-    expect_identical(p2$strategies[[1]]$control, ctrl_p)
-  }
-})
+# Now overwritten in call to SCM or Patch - will need appropriate test
+# test_that("Parameters overwrites Strategy control", {
+#   for (x in names(strategy_types)) {
+#     ctrl <- ctrl_s <- ctrl_p <- Control()
+#     ## set these just as markers:
+#     ctrl_s$schedule_eps <- 1
+#     ctrl_p$schedule_eps <- 2
+# 
+#     s <- strategy_types[[x]](control=ctrl_s)
+#     e <- environment_types[[x]]
+#     expect_identical(s$control, ctrl_s)
+#     expect_false(identical(s$control, ctrl_p))
+# 
+#     p <- Parameters(x, e)(control=ctrl_p)
+#     expect_false(identical(p$control, ctrl_s))
+#     expect_identical(p$control, ctrl_p)
+# 
+#     p$strategies <- list(s)
+#     p$birth_rate <- 1
+#     p$is_resident <- TRUE
+#     ## Pass though to force validation:
+#     tmp <- Patch(x, e)(p)$parameters
+#     expect_identical(tmp$control, ctrl_p)
+#     expect_identical(tmp$strategies[[1]]$control, ctrl_p)
+# 
+#     ## In one shot:
+#     p2 <- Parameters(x, e)(control=ctrl_p, strategies=list(s),
+#                            birth_rate=1, is_resident=TRUE)
+#     expect_identical(p2$control, ctrl_p)
+#     expect_identical(p2$strategies[[1]]$control, ctrl_p)
+#   }
+# })
 
 test_that("Generate cohort schedule", {
   for (x in names(strategy_types)) {

--- a/tests/testthat/test-patch.R
+++ b/tests/testthat/test-patch.R
@@ -16,7 +16,8 @@ for (x in names(strategy_types)) {
                         is_resident=TRUE,
                         patch_type = 'meta-population')
   
-  patch <- Patch(x, e)(p)
+  ctrl <- Control()
+  patch <- Patch(x, e)(p, ctrl)
   cmp <- Cohort(x, e)(p$strategies[[1]])
 
   test_that(sprintf("Basics %s", x), {
@@ -162,7 +163,9 @@ for (x in names(strategy_types)) {
   
   test_that("No Disturbance for fixed-time patches", {
     p$patch_type <- "fixed"
-    patch <- Patch(x, e)(p)
+    ctrl <- scm_base_control()
+
+    patch <- Patch(x, e)(p, ctrl)
     
     expect_identical(patch$time, 0.0)
     expect_identical(patch$pr_survival(patch$time), 1.0)

--- a/tests/testthat/test-schedule-build.R
+++ b/tests/testthat/test-schedule-build.R
@@ -18,9 +18,10 @@ test_that("Schedule building", {
     ## This is a really dumb test but it should act as a regression test
     ## at least.
     p <- scm_base_parameters(x)
+    ctrl <- scm_base_control()
     p$strategies <- list(strategy_types[[x]]())
     p$birth_rate <- 0.1
-    p <- build_schedule(p)
+    p <- build_schedule(p, ctrl)
     expect_equal(length(p$cohort_schedule_times_default), 141)
     expect_equal(length(p$cohort_schedule_times[[1]]), 176)
   }

--- a/tests/testthat/test-scm-support.R
+++ b/tests/testthat/test-scm-support.R
@@ -2,15 +2,16 @@ context("SCM support")
 
 
 test_that("collect / make_patch", {
+  ctrl <- scm_base_control()
   p0 <- scm_base_parameters()
   hyperpar <- make_FF16_hyperpar()
   p0$disturbance_mean_interval <- 30.0
   p1 <- expand_parameters(trait_matrix(0.08, "lma"), p0, hyperpar, FALSE)
 
-  res <- run_scm_collect(p1)
+  res <- run_scm_collect(p1, ctrl)
 
   st_113 <- scm_state(113, res)
-  p1_113 <- make_patch(st_113, p1)
+  p1_113 <- make_patch(st_113, p1, ctrl)
 
   expect_equal(p1_113$ode_state, unlist(st_113$species))
   expect_equal(p1_113$time, st_113$time)

--- a/tests/testthat/test-scm.R
+++ b/tests/testthat/test-scm.R
@@ -15,11 +15,13 @@ test_that("Run SCM", {
                           birth_rate=pi/2,
                           patch_area=10,
                           is_resident=TRUE)
+    
+    ctrl <- Control()
 
-    expect_error(scm <- SCM(x, e)(p), "Patch area must be exactly 1 for the SCM")
+    expect_error(scm <- SCM(x, e)(p, ctrl), "Patch area must be exactly 1 for the SCM")
 
     p$patch_area <- 1.0
-    scm <- SCM(x, e)(p)
+    scm <- SCM(x, e)(p, ctrl)
     expect_is(scm, sprintf("SCM<%s,%s>", x, e))
 
     ## NOTE: I'm not sure where these are only equal and not identical.
@@ -169,7 +171,8 @@ test_that("schedule setting", {
       birth_rate=pi/2,
       is_resident=TRUE,
       max_patch_lifetime=5.0)
-    scm <- SCM(x, e)(p)
+    ctrl <- scm_base_control()
+    scm <- SCM(x, e)(p, ctrl)
 
     ## Then set a cohort schedule:
     ## Build a schedule for 14 introductions from t=0 to t=5
@@ -190,7 +193,7 @@ test_that("schedule setting", {
     expect_identical(sched2$max_time, sched$max_time)
     expect_identical(sched2$all_times, list(t))
 
-    scm2 <- SCM(x, e)(p2)
+    scm2 <- SCM(x, e)(p2, ctrl)
     expect_identical(scm2$cohort_schedule$max_time, sched2$max_time)
     expect_identical(scm2$cohort_schedule$all_times, sched2$all_times)
   }
@@ -239,9 +242,10 @@ test_that("Seed rain & error calculations correct", {
     context(sprintf("SCM-%s", x))
     e <- environment_types[[x]]
     p0 <- scm_base_parameters(x)
+    ctrl <- scm_base_control()
     p1 <- expand_parameters(trait_matrix(0.08, "lma"), p0, mutant=FALSE)
 
-    scm <- run_scm(p1)
+    scm <- run_scm(p1, ctrl)
     expect_is(scm, sprintf("SCM<%s,%s>", x, e))
 
     net_reproduction_ratio_R <- function(scm, error=FALSE) {
@@ -267,7 +271,7 @@ test_that("Seed rain & error calculations correct", {
     S_D <- scm$parameters$strategies[[1]]$S_D
     expect_equal(int("offspring_produced_survival_weighted") * S_D, scm$net_reproduction_ratio_for_species(1))
 
-    res <- run_scm_collect(p1)
+    res <- run_scm_collect(p1, ctrl)
     int2 <- make_scm_integrate(res)
 
     expect_equal(int2("offspring_produced_survival_weighted"), int("offspring_produced_survival_weighted"))
@@ -282,7 +286,8 @@ test_that("Can create empty SCM", {
   for (x in names(strategy_types)) {
     e <- environment_types[[x]]
     p <- Parameters(x, e)()
-    scm <- SCM(x, e)(p)
+    ctrl <- scm_base_control()
+    scm <- SCM(x, e)(p, ctrl)
 
     ## Check light environment is empty:
     env <- scm$patch$environment

--- a/tests/testthat/test-stochastic-patch-runner.R
+++ b/tests/testthat/test-stochastic-patch-runner.R
@@ -9,10 +9,11 @@ test_that("empty", {
     set.seed(1)
     p <- Parameters(x, e)(strategies=list(strategy_types[[x]]()),
                           birth_rate=pi/2,
-                          is_resident=TRUE,
-                          control=fast_control())
+                          is_resident=TRUE)
+    
+    ctrl <- scm_base_control()
 
-    obj <- StochasticPatchRunner(x, e)(p)
+    obj <- StochasticPatchRunner(x, e)(p, ctrl)
     expect_identical(obj$time, 0.0)
 
     sched <- obj$schedule
@@ -54,10 +55,11 @@ test_that("collect", {
     p <- Parameters(x, e)(strategies=list(strategy_types[[x]]()),
                           birth_rate=5/50,
                           patch_area=50,
-                          is_resident=TRUE,
-                          control=fast_control())
+                          is_resident=TRUE)
     
-    expect_silent(res <- run_stochastic_collect(p))
+    ctrl <- Control()
+    
+    expect_silent(res <- run_stochastic_collect(p, ctrl))
     ## TODO: more tests on collect output
 
     ## This shows that we're probably over-aggressively killing plants.

--- a/tests/testthat/test-stochastic-patch.R
+++ b/tests/testthat/test-stochastic-patch.R
@@ -11,7 +11,8 @@ test_that("empty", {
     p <- Parameters(x, e)(strategies=list(strategy_types[[x]]()),
                           birth_rate=pi/2,
                           is_resident=TRUE)
-    patch <- StochasticPatch(x, e)(p)
+    ctrl <- Control()
+    patch <- StochasticPatch(x, e)(p, ctrl)
 
     expect_is(patch, sprintf("StochasticPatch<%s,%s>",x,e))
 
@@ -37,7 +38,8 @@ test_that("non empty", {
     p <- Parameters(x, e)(strategies=list(strategy_types[[x]]()),
                           birth_rate=pi/2,
                           is_resident=TRUE)
-    patch <- StochasticPatch(x, e)(p)
+    ctrl <- Control()
+    patch <- StochasticPatch(x, e)(p, ctrl)
     cmp <- Individual(x, e)(p$strategies[[1]])
 
     expect_error(patch$introduce_new_cohort(0), "Invalid value")

--- a/tests/testthat/test-strategy-ff16.R
+++ b/tests/testthat/test-strategy-ff16.R
@@ -176,19 +176,20 @@ test_that("narea calculation", {
 test_that("offspring arrival", {
 
   p0 <- scm_base_parameters("FF16")
+  ctrl <- scm_base_control()
 
   # one species
   p1 <- expand_parameters(trait_matrix(0.0825, "lma"), p0, FF16_hyperpar,FALSE)
 
   p1$birth_rate <- 20
-  out <- run_scm(p1)
+  out <- run_scm(p1, ctrl)
   expect_equal(out$offspring_production, 16.88946, tolerance=1e-5)
   expect_equal(out$ode_times[c(10, 100)], c(0.000070, 4.216055), tolerance=1e-5)
 
   # two species
   p2 <- expand_parameters(trait_matrix(0.2625, "lma"), p1, FF16_hyperpar, FALSE)
   p2$birth_rate <- c(11.99177, 16.51006)
-  out <- run_scm(p2)
+  out <- run_scm(p2, ctrl)
   expect_equal(out$offspring_production, c(11.99529, 16.47519), tolerance=1e-5)
   expect_equal(length(out$ode_times), 297)
 })

--- a/tests/testthat/test-strategy-k93.R
+++ b/tests/testthat/test-strategy-k93.R
@@ -75,12 +75,14 @@ test_that("K93 seed rain is unchanged", {
   # Generic parameters
   p0 <- scm_base_parameters("K93")
   p0$max_patch_lifetime <- 35.10667
+  
+  ctrl <- scm_base_control()
 
   # Use single sp. defaults
   p1 <- expand_parameters(trait_matrix(0.059, "b_0"), p0, mutant = FALSE)
   p1$birth_rate <- 20
 
-  out <- run_scm(p1)
+  out <- run_scm(p1, ctrl)
   expect_equal(out$offspring_production, 0.0753, tolerance = 1e-4)
 
   # Three species from paper
@@ -96,7 +98,7 @@ test_that("K93 seed rain is unchanged", {
 
   p2 <- expand_parameters(sp, p0, mutant = FALSE)
   p2$birth_rate <- c(20, 20, 20)
-  out <- run_scm(p2)
+  out <- run_scm(p2, ctrl)
 
   expect_equal(out$offspring_production, c(0.0025, 0.2321, 0.2194), tolerance = 1e-4)
 })

--- a/tests/testthat/test-strategy-water.R
+++ b/tests/testthat/test-strategy-water.R
@@ -36,11 +36,14 @@ test_that("Basic run", {
   p0 <- scm_base_parameters("Water")
   p1 <- expand_parameters(trait_matrix(0.0825, "lma"), p0, Water_hyperpar,FALSE)
 
+
   p1$birth_rate <- 20
-  p1$control$soil_infiltration_rate <- 1
-  p1$control$soil_number_of_depths <- 10
+
+  ctrl <- scm_base_control()
+  ctrl$soil_infiltration_rate <- 1
+  ctrl$soil_number_of_depths <- 10
   
-  out <- run_scm(p1)
+  out <- run_scm(p1, ctrl)
   
   expect_equal(out$patch$environment$ode_size, 10)
 

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -4,12 +4,12 @@ test_that("Some support functions", {
   expect_is(fast_control(), "Control")
   expect_is(equilibrium_verbose(), "Control")
   expect_is(equilibrium_quiet(), "Control")
-  p <- scm_base_parameters()
-  expect_is(p, "Parameters<FF16,FF16_Env>")
+  base <- scm_base_control()
+  expect_is(base, "Control")
   cmp <- equilibrium_verbose(fast_control())
   cmp$schedule_eps <- 0.005
   cmp$equilibrium_eps <- 1e-3
-  expect_equal(p$control, cmp)
+  expect_equal(base, cmp)
 })
 
 test_that("assembly_parameters", {


### PR DESCRIPTION
One step closer to #306.

This removes the Control object from Parameters and passes it directly to SCM or Patch APIs as required. This is handled on the R side with what I hope are sensible defaults, so most often users won't notice it's even there.

```
result <- run_scm_collect(p = expand_parameters(p0, trait_matrix), 
                          control = scm_base_control())
```

All tests pass, but I didn't test the carrying capacity or equilibrium scripts as I'm not totally sure what the correct output should be. Please let me know if there's anything that looks like it needs further investigation.

Next step will be repeating this exercise with Environment.