### PR TITLE
Compiler warnings fix

### DIFF
--- a/inst/include/plant/cohort.h
+++ b/inst/include/plant/cohort.h
@@ -175,7 +175,7 @@ double Cohort<T,E>::competition_effect() const {
 // only Patch and above does.
 template <typename T, typename E>
 ode::const_iterator Cohort<T,E>::set_ode_state(ode::const_iterator it) {
-  for (int i = 0; i < plant.ode_size(); i++) {
+  for (size_t i = 0; i < plant.ode_size(); i++) {
     plant.set_state(i, *it++);
   }
   offspring_produced_survival_weighted = *it++;
@@ -184,7 +184,7 @@ ode::const_iterator Cohort<T,E>::set_ode_state(ode::const_iterator it) {
 }
 template <typename T, typename E>
 ode::iterator Cohort<T,E>::ode_state(ode::iterator it) const {
-  for (int i = 0; i < plant.ode_size(); i++) {
+  for (size_t i = 0; i < plant.ode_size(); i++) {
     *it++ = plant.state(i);
   }
   *it++ = offspring_produced_survival_weighted;
@@ -193,7 +193,7 @@ ode::iterator Cohort<T,E>::ode_state(ode::iterator it) const {
 }
 template <typename T, typename E>
 ode::iterator Cohort<T,E>::ode_rates(ode::iterator it) const {
-  for (int i = 0; i < plant.ode_size(); i++) {
+  for (size_t i = 0; i < plant.ode_size(); i++) {
     *it++ = plant.rate(i);
   }
   *it++ = offspring_produced_survival_weighted_dt;

--- a/inst/include/plant/disturbance_regime.h
+++ b/inst/include/plant/disturbance_regime.h
@@ -14,7 +14,10 @@ public:
   virtual double cdf(double time) const {return NA_REAL;}
   virtual double icdf(double p) const {return NA_REAL;}
   virtual double r_mean_interval() const {return NA_REAL;}
-
+  /* base class should define virtual destructor to avoid undefined behaviour 
+  when static and dynamic types differ for an object (ie through pointers) and 
+  an attempt to delete it is made */
+  virtual ~Disturbance_Regime() = default;
   std::vector<double> r_density(std::vector<double> time) const;
 };
 

--- a/inst/include/plant/environment.h
+++ b/inst/include/plant/environment.h
@@ -31,21 +31,21 @@ public:
   virtual void compute_rates(){};
 
   ode::const_iterator set_ode_state(ode::const_iterator it) {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       vars.states[i] = *it++;
     }
     return it;
   }
 
   ode::iterator ode_state(ode::iterator it) const {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       *it++ = vars.states[i];
     }
     return it;
   }
 
   ode::iterator ode_rates(ode::iterator it) const {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       *it++ = vars.rates[i];
     }
     return it;

--- a/inst/include/plant/environment.h
+++ b/inst/include/plant/environment.h
@@ -16,7 +16,6 @@ namespace plant {
 
 class Environment {
 public:
-
   template <typename Function>
   void compute_environment(Function f, double height_max);
   template <typename Function>
@@ -62,6 +61,8 @@ public:
   void r_init_interpolators(const std::vector<double>& state) {}
 
   double get_environment_at_height(double height) { return 0.0; };
+  
+  virtual ~Environment() = default;
 
   double time;
 

--- a/inst/include/plant/get_state.h
+++ b/inst/include/plant/get_state.h
@@ -102,7 +102,7 @@ Rcpp::List get_state(const StochasticPatchRunner<T,E>& obj) {
   return List::create(_["time"] = obj.time(),
                       _["species"] = get_state(patch),
                       _["env"] = get_state(patch.r_environment()));
-};
+}
 
 }
 

--- a/inst/include/plant/individual.h
+++ b/inst/include/plant/individual.h
@@ -80,20 +80,20 @@ public:
   std::vector<std::string> aux_names() { return strategy->aux_names(); }
 
   ode::const_iterator set_ode_state(ode::const_iterator it) {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       vars.states[i] = *it++;
       strategy->update_dependent_aux(i, vars);
     }
     return it;
   }
   ode::iterator ode_state(ode::iterator it) const {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       *it++ = vars.states[i];
     }
     return it;
   }
   ode::iterator ode_rates(ode::iterator it) const {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       *it++ = vars.rates[i];
     }
     return it;

--- a/inst/include/plant/models/ff16_environment.h
+++ b/inst/include/plant/models/ff16_environment.h
@@ -55,7 +55,7 @@ public:
   double soil_infiltration_rate;
 
   virtual void compute_rates() {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       vars.set_rate(i, soil_infiltration_rate / (i+1));
     }
   }
@@ -69,7 +69,7 @@ public:
 
   // R interface
   void set_soil_water_state(std::vector<double> state) {
-    for (int i = 0; i < vars.state_size; i++) {
+    for (size_t i = 0; i < vars.state_size; i++) {
       vars.set_state(i, state[i]);
     }
   }

--- a/inst/include/plant/patch.h
+++ b/inst/include/plant/patch.h
@@ -102,9 +102,9 @@ private:
 template <typename T, typename E>
 Patch<T,E>::Patch(parameters_type p, environment_type e, Control c)
   : parameters(p),
+    is_resident(p.is_resident),
     environment(e),
-    control(c),
-    is_resident(p.is_resident) {
+    control(c) {
   parameters.validate();
 
   survival_weighting = p.disturbance;

--- a/inst/include/plant/stochastic_patch.h
+++ b/inst/include/plant/stochastic_patch.h
@@ -86,9 +86,9 @@ private:
 template <typename T, typename E>
 StochasticPatch<T,E>::StochasticPatch(parameters_type p, environment_type e, Control c)
   : parameters(p),
+    is_resident(p.is_resident),
     environment(e),
-    control(c),
-    is_resident(p.is_resident) {
+    control(c) {
   parameters.validate();
   for (auto s : parameters.strategies) {
     s.control = control;

--- a/inst/include/plant/stochastic_patch.h
+++ b/inst/include/plant/stochastic_patch.h
@@ -131,7 +131,7 @@ double StochasticPatch<T,E>::compute_competition(double height) const {
 
 template <typename T, typename E>
 void StochasticPatch<T,E>::compute_environment() {
-  if (parameters.n_residents() > 0 & height_max() > 0.0) {
+  if (parameters.n_residents() > 0 && height_max() > 0.0) {
     auto f = [&] (double x) -> double {return compute_competition(x);};
     environment.compute_environment(f, height_max());
   } else {
@@ -141,7 +141,7 @@ void StochasticPatch<T,E>::compute_environment() {
 
 template <typename T, typename E>
 void StochasticPatch<T,E>::rescale_environment() {
-  if (parameters.n_residents() > 0 & height_max() > 0.0) {
+  if (parameters.n_residents() > 0 && height_max() > 0.0) {
     auto f = [&] (double x) -> double {return compute_competition(x);};
     environment.rescale_environment(f, height_max());
   }

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,3 +1,3 @@
 ## -*- makefile -*-
 CXX_STD = CXX11
-PKG_CPPFLAGS = -I../inst/include/
+PKG_CPPFLAGS = -isystem../inst/include/

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -19,10 +19,10 @@ void FF16_Strategy::refresh_indices () {
   aux_index   = std::map<std::string,int>();
   std::vector<std::string> aux_names_vec = aux_names();
   std::vector<std::string> state_names_vec = state_names();
-  for (int i = 0; i < state_names_vec.size(); i++) {
+  for (size_t i = 0; i < state_names_vec.size(); i++) {
     state_index[state_names_vec[i]] = i;
   }
-  for (int i = 0; i < aux_names_vec.size(); i++) {
+  for (size_t i = 0; i < aux_names_vec.size(); i++) {
     aux_index[aux_names_vec[i]] = i;
   }
 }

--- a/src/k93_strategy.cpp
+++ b/src/k93_strategy.cpp
@@ -54,7 +54,7 @@ double K93_Strategy::compute_competition(double z, double size) const {
 
   // Competition only felt if plant bigger than target size z
   return k_I * size_to_basal_area(size) * Q(z, size);
- };
+ }
 
 double K93_Strategy::establishment_probability(const K93_Environment& environment){
   //TODO: may want to make this dependent on achieving positive growth rate
@@ -74,10 +74,10 @@ void K93_Strategy::refresh_indices () {
   aux_index   = std::map<std::string,int>();
   std::vector<std::string> aux_names_vec = aux_names();
   std::vector<std::string> state_names_vec = state_names();
-  for (int i = 0; i < state_names_vec.size(); i++) {
+  for (size_t i = 0; i < state_names_vec.size(); i++) {
     state_index[state_names_vec[i]] = i;
   }
-  for (int i = 0; i < aux_names_vec.size(); i++) {
+  for (size_t i = 0; i < aux_names_vec.size(); i++) {
     aux_index[aux_names_vec[i]] = i;
   }
 }


### PR DESCRIPTION
This PR fixes almost all compiler warnings in the `develop` branch including the Rcpp and Boost warnings from #311. The only remaining warning is
```
 ff16w_strategy.cpp: In member function ‘virtual double plant::FF16w_Strategy::net_mass_production_dt(const plant::FF16_Environment&, double, double, bool)’:
 ff16w_strategy.cpp:30:16: warning: unused variable ‘water_’ [-Wunused-variable]
    30 |   const double water_ = water_access(environment, height, area_leaf_);
```
which I think is fine as the file doesn't seem to be fully implemented yet. It would be good to get a sanity check that the compilation process still works on other machines.