### PR TITLE
Move `compute_assimilation` into FF16 Strategy as a lambda

### DIFF
--- a/inst/include/plant/models/assimilation.h
+++ b/inst/include/plant/models/assimilation.h
@@ -29,7 +29,6 @@ class Assimilation {
   // Falster 2012), we do not normalise by a_y*a_bio here.
   double assimilate(std::function<double(double)> f,
                     double height,
-                    const E &environment,
                     double area_leaf,
                     bool reuse_intervals) {
 

--- a/inst/include/plant/models/ff16_strategy.h
+++ b/inst/include/plant/models/ff16_strategy.h
@@ -88,6 +88,8 @@ public:
   double mass_above_ground(double mass_leaf, double mass_bark,
                            double mass_sapwood, double mass_root) const;
 
+  double compute_assimilation(double z, double height,
+                              const FF16_Environment &environment);
 
   void compute_rates(const FF16_Environment& environment, bool reuse_intervals,
                 Internals& vars);

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,11 +6,6 @@
 
 using namespace Rcpp;
 
-#ifdef RCPP_USE_GLOBAL_ROSTREAM
-Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
-Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
-#endif
-
 // Lorenz__ctor
 plant::ode::test::Lorenz Lorenz__ctor(double sigma, double R, double b);
 RcppExport SEXP _plant_Lorenz__ctor(SEXP sigmaSEXP, SEXP RSEXP, SEXP bSEXP) {

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -230,7 +230,7 @@ double FF16_Strategy::net_mass_production_dt(const FF16_Environment& environment
   };
 
   const double assimilation_ = assimilator.assimilate(
-    f, height, environment, area_leaf_, reuse_intervals);
+    f, height, area_leaf_, reuse_intervals);
 
   const double respiration_ =
     respiration(mass_leaf_, mass_sapwood_, mass_bark_, mass_root_);
@@ -403,9 +403,9 @@ double FF16_Strategy::mortality_growth_dependent_dt(double productivity_area) co
 
 // [eqn 20] Survival of seedlings during establishment
 double FF16_Strategy::establishment_probability(const FF16_Environment& environment) {
-  
+
   double decay_over_time = exp(-recruitment_decay * environment.time);
-  
+
   const double net_mass_production_dt_ =
     net_mass_production_dt(environment, height_0, area_leaf_0);
   if (net_mass_production_dt_ > 0) {


### PR DESCRIPTION
Draft of changes to modularise how assimilation is calculated. Where previously the per-leaf photosynthetic canopy was hard-coded, it now resides in `FF16_Strategy::compute_assimilation` which is passed to `assimilation::assimilate` for integration along the distribution of canopy openness
 during calculation of `net_mass_production_dt`.

I've left the leaf level approximation in `assimilation` for now, which can be accessed from the `assimilator` object -

```c++
// ff16_strategy.cpp
double FF16_Strategy::compute_assimilation(double z, double height,
                                     const FF16_Environment& environment) {
  return assimilator.assimilation_leaf(environment.get_environment_at_height(z)) * assimilator.q(z, height);
}
```

When FF16w comes online, we can substitute in a new method while also reusing `q` to access information about the distribution of leaf area -

```c++
// ff16w_strategy.cpp
double FF16w_Strategy::compute_assimilation(double z, double height,
                                     const FF16_Environment& environment) {
  // something like..
  return leaf::assimilation(environment.get_environment_at_height(z)) * assimilator.q(z, height);
}
```

The only requirements are to return a double and scale the result by `area_leaf`:

```c++
// assimilation.h
double assimilate(std::function<double(double)> f, ...) {
    ...
    return area_leaf * A;
}
```

We can modify this last line if additional scaling terms are needed and set them to 1 in FF16 to maintain backwards compatibility.