### PR TITLE
Fix incorrect renaming of net_reproduction_ratio_errors

### DIFF
--- a/R/scm_support.R
+++ b/R/scm_support.R
@@ -186,14 +186,14 @@ run_scm_error <- function(p, env = make_environment(parameters = p),
   rbind_list <- function(x) do.call("rbind", as.list(x))
 
   lai_error <- lapply(lai_error, function(x) rbind_list(pad_matrix(x)))
-  average_fecundity_error <- scm$average_fecundity_error
+  net_reproduction_ratio_errors <- scm$net_reproduction_ratio_errors
   f <- function(m) {
     suppressWarnings(apply(m, 2, max, na.rm=TRUE))
   }
   total <- lapply(seq_len(n_spp), function(idx)
-                  f(rbind(lai_error[[idx]], average_fecundity_error[[idx]])))
+                  f(rbind(lai_error[[idx]], net_reproduction_ratio_errors[[idx]])))
   list(offspring_production=scm$offspring_production,
-       err=list(lai=lai_error, offspring_production=average_fecundity_error, total=total),
+       err=list(lai=lai_error, offspring_production=net_reproduction_ratio_errors, total=total),
        ode_times=scm$ode_times)
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -75,7 +75,7 @@ std::vector<double> local_error_integration(const std::vector<double>& x,
   std::vector<double> ret;
   check_length(x.size(), y.size());
 
-  if (x.size() < 3) {
+  if ((x.size() < 3) || (scal == 0)) {
     for (size_t i = 0; i < x.size(); ++i) {
       ret.push_back(NA_REAL);
     }

--- a/tests/testthat/test-schedule-build.R
+++ b/tests/testthat/test-schedule-build.R
@@ -24,6 +24,6 @@ test_that("Schedule building", {
 
     p <- build_schedule(p, env, ctrl)
     expect_equal(length(p$node_schedule_times_default), 141)
-    expect_equal(length(p$node_schedule_times[[1]]), 176)
+    expect_equal(length(p$node_schedule_times[[1]]), 186)
   }
 })

--- a/tests/testthat/test-trapezium.R
+++ b/tests/testthat/test-trapezium.R
@@ -10,7 +10,7 @@ test_that("Trapezium rule works", {
 })
 
 test_that("Trapezium local error estimate is correct", {
-  ## Here is the naive implementation of integration error...
+  ## Here is a naive implementation of integration error for comparison with C++ version
   local_error_integration_R <- function(x, y) {
     n <- length(x)
     i0 <- -c(n-1, n)


### PR DESCRIPTION
Fix incorrect renaming of net_reproduction_ratio_errors

in 3200b2d in `R/scm_support.R`
- `seed_rain_error` was renamed to `average_fecundity_error`, which returns NULL
- should be `net_reproduction_ratio_errors` to match change in RcppR6_classes.yml

this fix exposed a need to guard against case where scalar is 0 + fix test
- this was happening when total_offspring = 0
