### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,7 +36,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Updates `actions/checkout@v3` → `@v4` in both workflows to resolve the GitHub Actions Node.js 20 deprecation warning (runners force Node.js 24 starting June 16th, 2026).

- `.github/workflows/R-CMD-check.yaml`
- `.github/workflows/benchmarks.yml`

The `r-lib/actions/*` actions are already on `@v2`, which supports current Node versions, so no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)