### PR TITLE
K93 SCM perf: ~5x scm / ~12x build_schedule (FF16-parity + tolerance tuning)

### DIFF
--- a/inst/include/plant/interpolator.h
+++ b/inst/include/plant/interpolator.h
@@ -3,8 +3,8 @@
 #define PLANT_PLANT_INTERPOLATOR_H_
 
 #include <vector>
+#include <limits> // std::numeric_limits
 #include <RcppCommon.h> // SEXP
-#include <R_ext/Arith.h> // R_PosInf, R_NegInf
 #include <tk/spline.h>
 #include <plant/util.h> // util::stop (for inline eval/check_active)
 
@@ -40,8 +40,8 @@ public:
   // These are chosen so that if a Interpolator is empty, functions looking to
   // see if they will fall outside of the covered range will always find they
   // do.  This is the same principle as R's range(numeric(0)) -> c(Inf, -Inf).
-  double min() const { return size() > 0 ? x.front() : R_PosInf; }
-  double max() const { return size() > 0 ? x.back() : R_NegInf; }
+  double min() const { return size() > 0 ? x.front() : std::numeric_limits<double>::infinity(); }
+  double max() const { return size() > 0 ? x.back() : -std::numeric_limits<double>::infinity(); }
   void set_extrapolate(bool e);
 
   std::vector<double> get_x() const;

--- a/inst/include/plant/models/k93_environment.h
+++ b/inst/include/plant/models/k93_environment.h
@@ -13,8 +13,16 @@ class K93_Environment : public Environment {
 public:
   K93_Environment() {
     time = 0.0;
-    light_availability = ResourceSpline();
-    light_availability.spline_rescale_usually = true;
+    // Match FF16: loosen the light-availability spline tolerance from the
+    // ResourceSpline default (1e-6) to 1e-4 for speed. The spline is rebuilt
+    // every ODE step, so its construction dominates K93 runtime; 1e-6 was 100x
+    // tighter than FF16 for no comparable accuracy need.
+    light_availability = ResourceSpline(
+        1e-4, // light_availability_spline_tol
+        17,   // light_availability_spline_nbase
+        16,   // light_availability_spline_max_depth
+        true  // light_availability_spline_rescale_usually
+    );
   };
 
   // Light interface

--- a/inst/include/plant/models/k93_strategy.h
+++ b/inst/include/plant/models/k93_strategy.h
@@ -44,10 +44,18 @@ public:
                                 double height_inverse);
 
   double compute_competition(double z, double size) const;
+  // Hot path (called per node from Species::compute_competition): defined inline
+  // here so the no-LTO build folds it into the loop instead of paying a cross-TU
+  // call (mirrors FF16_Strategy; see the profile-plant skill).
   double compute_competition(double z, double whole_plant_competition,
-                             double height_inverse) const;
+                             double height_inverse) const {
+    return compute_competition_by_ratio(z * height_inverse, whole_plant_competition);
+  }
   double compute_competition_by_ratio(double z_over_size,
-                                      double whole_plant_competition) const;
+                                      double whole_plant_competition) const {
+    // Competition only felt if plant bigger than target size z.
+    return whole_plant_competition * canopy_shape.Q(z_over_size);
+  }
 
   void update_dependent_aux(const int index, Internals& vars);
 

--- a/inst/include/plant/models/k93_strategy.h
+++ b/inst/include/plant/models/k93_strategy.h
@@ -14,6 +14,13 @@ public:
   typedef std::shared_ptr<K93_Strategy> ptr;
   K93_Strategy();
 
+  // Direct aux indices for the hot path, avoiding aux_index.at("...") string-map
+  // lookups (these showed up in profiling; see #466). MUST stay in sync with the
+  // order of aux_names() below. refresh_indices() still fills the named maps used
+  // by the R-facing paths.
+  static constexpr int COMPETITION_EFFECT_AUX_INDEX = 0;
+  static constexpr int HEIGHT_INVERSE_AUX_INDEX = 1;
+
   // update this when the length of state_names changes
   static size_t state_size () { return 3; }
   // update this when the length of aux_names changes

--- a/inst/include/plant/node.h
+++ b/inst/include/plant/node.h
@@ -6,6 +6,7 @@
 #include <plant/gradient.h>
 #include <plant/ode_solver/ode_interface.h>
 #include <optional>
+#include <limits> // std::numeric_limits
 
 namespace plant {
 
@@ -101,7 +102,7 @@ private:
 template <typename T, typename E>
 Node<T,E>::Node(strategy_type_ptr s)
   : individual(s),
-    log_density(R_NegInf),
+    log_density(-std::numeric_limits<double>::infinity()),
     log_density_dt(0),
     density(0),
     offspring_produced_survival_weighted(0),
@@ -123,7 +124,7 @@ void Node<T,E>::compute_rates(const environment_type& environment,
   // survival_individual: converts from the mean of the poisson process (on
   // [0,Inf)) to a probability (on [0,1]).
   double survival_individual = exp(-individual.state(MORTALITY_INDEX));
-  if (!R_FINITE(survival_individual)) {
+  if (!util::is_finite(survival_individual)) {
     // This is caused by NaN values in plant.mortality and log
     // density; this should only be an issue when density is so low
     // that we can throw these away.  I think that with smaller step
@@ -157,7 +158,7 @@ void Node<T,E>::compute_initial_conditions(const environment_type& environment,
   // Need to check that the rates are valid after setting the
   // mortality value here (can go to -Inf and that requires squashing
   // the rate to zero).
-  if (!R_FINITE(log_density)) {
+  if (!util::is_finite(log_density)) {
     // Can do this at the same time that we do set_log_density, I think.
     log_density_dt = 0.0;
   }

--- a/inst/include/plant/node.h
+++ b/inst/include/plant/node.h
@@ -120,7 +120,7 @@ void Node<T,E>::compute_rates(const environment_type& environment,
   // need mortality_dt() that's always going to be the case.
   log_density_dt =
     - growth_rate_gradient(environment)
-    - individual.rate("mortality");
+    - individual.rate(MORTALITY_INDEX);
   // survival_individual: converts from the mean of the poisson process (on
   // [0,Inf)) to a probability (on [0,1]).
   double survival_individual = exp(-individual.state(MORTALITY_INDEX));
@@ -133,7 +133,7 @@ void Node<T,E>::compute_rates(const environment_type& environment,
   }
 
   offspring_produced_survival_weighted_dt =
-    individual.rate("fecundity") * survival_individual *
+    individual.rate(FECUNDITY_INDEX) * survival_individual *
     pr_patch_survival / pr_patch_survival_at_birth;
 }
 
@@ -151,7 +151,7 @@ void Node<T,E>::compute_initial_conditions(const environment_type& environment,
 
   const double pr_estab = individual.establishment_probability(environment);
   individual.set_state("mortality", -log(pr_estab));
-  const double g = individual.rate("height");
+  const double g = individual.rate(HEIGHT_INDEX);
   // NOTE: log(0.0) -> -Inf, which should behave fine.
   set_log_density(g > 0 ? log(birth_rate * pr_estab / g) : log(0.0));
 
@@ -193,7 +193,7 @@ double Node<T,E>::growth_rate_gradient(const environment_type& environment) cons
     return util::gradient_richardson(fun,  individual.state(HEIGHT_INDEX), eps,
                                      control.node_gradient_richardson_depth);
   } else {
-    return util::gradient_fd(fun, individual.state(HEIGHT_INDEX), eps, individual.rate("height"),
+    return util::gradient_fd(fun, individual.state(HEIGHT_INDEX), eps, individual.rate(HEIGHT_INDEX),
                              control.node_gradient_direction);
   }
 }

--- a/inst/include/plant/util.h
+++ b/inst/include/plant/util.h
@@ -4,7 +4,8 @@
 
 #include <stddef.h> // size_t
 #include <RcppCommon.h> // as/wrap/SEXP
-#include <R_ext/Arith.h> // R_FINITE
+#include <R_ext/Arith.h> // NA_REAL etc. (kept; widely relied on transitively)
+#include <cmath> // std::isfinite
 
 namespace plant {
 namespace util {
@@ -27,8 +28,12 @@ inline std::vector<index> index_vector(const std::vector<size_t> x) {
 
 // Inline so the hot per-node competition loop (Species::compute_competition)
 // does not pay a cross-TU call for this trivial check (no LTO in this build).
+// std::isfinite inlines to a couple of FP instructions; R_FINITE() compiled to
+// a cross-library call into libR's R_finite() here, which dominated the K93
+// competition loop. Equivalent semantics (NaN/Inf/NA_real_ all -> false) under
+// the package's -O2 (no -ffast-math) build.
 inline bool is_finite(double x) {
-  return R_FINITE(x);
+  return std::isfinite(x);
 }
 
 void check_length(size_t received, size_t expected);

--- a/src/control.cpp
+++ b/src/control.cpp
@@ -45,7 +45,7 @@ Control::Control() {
   fixed_time_step   = 0.0;
 
   schedule_nsteps   = 20;
-  schedule_eps      = 5e-3;
+  schedule_eps      = 2e-2;
   schedule_verbose  = false;
 
   save_RK45_cache = false;

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -438,7 +438,7 @@ double FF16_Strategy::mortality_dt(double productivity_area,
   // levels and the rate of change won't matter.  It is possible that
   // we will need to trim this to some large finite value, but for
   // now, just checking that the actual mortality rate is finite.
-  if (R_FINITE(cumulative_mortality)) {
+  if (util::is_finite(cumulative_mortality)) {
     return
       mortality_growth_independent_dt() +
       mortality_growth_dependent_dt(productivity_area);

--- a/src/k93_strategy.cpp
+++ b/src/k93_strategy.cpp
@@ -26,10 +26,10 @@ K93_Strategy::K93_Strategy() {
 void K93_Strategy::update_dependent_aux(const int index, Internals& vars) {
   if (index == HEIGHT_INDEX) {
     double height = vars.state(HEIGHT_INDEX);
-    vars.set_aux(aux_index.at("competition_effect"),
+    vars.set_aux(COMPETITION_EFFECT_AUX_INDEX,
                  compute_competition_by_ratio(
                    0.0, k_I * size_to_basal_area(height)));
-    vars.set_aux(aux_index.at("height_inverse"), 1.0 / height);
+    vars.set_aux(HEIGHT_INVERSE_AUX_INDEX, 1.0 / height);
   }
 }
 

--- a/src/k93_strategy.cpp
+++ b/src/k93_strategy.cpp
@@ -37,17 +37,9 @@ double K93_Strategy::compute_competition(double z, double size) const {
   return compute_competition(z, k_I * size_to_basal_area(size), 1.0 / size);
 }
 
-double K93_Strategy::compute_competition(
-    double z, double whole_plant_competition, double height_inverse) const {
-  return compute_competition_by_ratio(
-    z * height_inverse, whole_plant_competition);
-}
-
-double K93_Strategy::compute_competition_by_ratio(
-    double z_over_size, double whole_plant_competition) const {
-  // Competition only felt if plant bigger than target size z.
-  return whole_plant_competition * canopy_shape.Q(z_over_size);
-}
+// compute_competition(z, whole_plant_competition, height_inverse) and
+// compute_competition_by_ratio() are defined inline in k93_strategy.h so the
+// per-node hot loop folds them in (no cross-TU call in this no-LTO build).
 
 double K93_Strategy::establishment_probability(const K93_Environment& environment){
   (void) environment;
@@ -151,7 +143,7 @@ double K93_Strategy::mortality_dt(double cumulative_basal_area,
   // If mortality probability is 1 (latency = Inf) then the rate
   // calculations break.  Setting them to zero gives the correct
   // behaviour.
-  if (R_FINITE(cumulative_mortality)) {
+  if (util::is_finite(cumulative_mortality)) {
     double mu = -c_0 + c_1 * cumulative_basal_area;
     return (mu > 0)? mu:0.0;
  } else {

--- a/src/node_schedule.cpp
+++ b/src/node_schedule.cpp
@@ -3,12 +3,13 @@
 #include <plant/util.h>
 #include <Rcpp.h>
 #include <cmath> // log2, exp2
+#include <limits> // std::numeric_limits
 
 namespace plant {
 
 NodeSchedule::NodeSchedule(size_t n_species_)
   : n_species(n_species_),
-    max_time(R_PosInf),
+    max_time(std::numeric_limits<double>::infinity()),
     use_ode_times(false) {
   reset();
 }

--- a/src/tf24_strategy.cpp
+++ b/src/tf24_strategy.cpp
@@ -618,7 +618,7 @@ double TF24_Strategy::mortality_dt(double productivity_area,
   // levels and the rate of change won't matter.  It is possible that
   // we will need to trim this to some large finite value, but for
   // now, just checking that the actual mortality rate is finite.
-  if (R_FINITE(cumulative_mortality)) {
+  if (util::is_finite(cumulative_mortality)) {
     return
       mortality_growth_independent_dt() +
       mortality_growth_dependent_dt(productivity_area);

--- a/tests/testthat/test-control.R
+++ b/tests/testthat/test-control.R
@@ -27,7 +27,7 @@ test_that("Defaults", {
     save_RK45_cache = FALSE,
 
     schedule_nsteps   = 20, # size_t
-    schedule_eps      = 5e-3,
+    schedule_eps      = 2e-2,
     schedule_verbose  = FALSE,
     
     GSS_tol_abs = 1e-3,

--- a/tests/testthat/test-schedule-build.R
+++ b/tests/testthat/test-schedule-build.R
@@ -27,7 +27,7 @@ test_that("Schedule building", {
     p2 <- scm$parameters
 
     expect_equal(length(p2$node_schedule_times_default), 141)
-    expect_equal(length(p2$node_schedule_times[[1]]), 186)
+    expect_equal(length(p2$node_schedule_times[[1]]), 148)
 
     ## Refinement leaves the Parameters self-describing (schedule + ode times).
     expect_equal(length(p2$ode_times), length(scm$ode_times))

--- a/tests/testthat/test-support.R
+++ b/tests/testthat/test-support.R
@@ -10,7 +10,7 @@ test_that("Control presets", {
   expect_equal(Control()$ode_tol_abs, 1e-4)
   expect_equal(Control()$ode_step_size_max, 5)
   expect_equal(Control()$node_gradient_direction, -1)
-  expect_equal(Control()$schedule_eps, 5e-3)
+  expect_equal(Control()$schedule_eps, 2e-2)
 
   ## control_accurate() tightens the ODE and schedule tolerances
   acc <- control_accurate()


### PR DESCRIPTION
## What

Speeds up the K93 SCM by **~5× (`scm`)** and **~12× (`build_schedule`)**, found via the `profile-plant` skill. Profiling showed ~95% of K93 time in generic SCM/competition machinery, not K93's (trivial, analytic) equations — and that K93 was missing several optimisations FF16 already had.

| K93 (one-iter, sample off) | baseline | this branch | speedup |
|---|---:|---:|---:|
| `scm` | 168 ms | **33 ms** | ~5× |
| `build_schedule` | 2.13 s | **0.18 s** | ~12× |

Full test suite passes on every commit.

## Commits

**Bit-identical speedups** (no result change; targeted strategy/individual/scm/node tests pass with no tolerance changes):
1. **Inline K93 `compute_competition`** into the header — it was out-of-line, so the no-LTO build paid a cross-TU call per node in `Species::compute_competition` (the #1 hotspot). Also migrates `R_FINITE`→`std::isfinite` (was a cross-*library* call into libR) and `R_PosInf/R_NegInf`→`std::numeric_limits` (so `interpolator.h` no longer needs `R_ext/Arith.h`).
2. **Cache K93 aux indices** — `update_dependent_aux` did `aux_index.at("...")` `std::map<string,int>` lookups per step; use `constexpr` index constants (mirrors FF16).
3. **Node hot-path int indices** (all strategies) — `Node::compute_rates`/`growth_rate_gradient` resolved rates by string name (`rate("mortality"/"fecundity"/"height")` → `map::at`) per node per step; use `MORTALITY_INDEX/FECUNDITY_INDEX/HEIGHT_INDEX`. Also speeds up FF16/TF24.

**Accuracy / speed tradeoffs** (not bit-identical — flagged for review):
4. **Default `schedule_eps` 5e-3 → 2e-2** (global) — schedule refinement converges to ~7e-7 relative by 2e-2 while halving `build_schedule`. `control_accurate()` still uses 1e-3. Updates default-assertion tests + the FF16 node-count regression pin (186→148); `test-mutant`/`test-scm` pass within existing tolerances.
5. **K93 env light-spline tol 1e-6 → 1e-4** (FF16 parity) — `K93_Environment` built its light-availability spline 100× tighter than FF16 (which explicitly uses 1e-4 "for speed") via the `ResourceSpline` default ctor. That per-step spline construction was the dominant cost; matching FF16 cut `compute_competition` ~9×. All K93 reference tests pass within tolerance.

## Notes

- The `profile-plant` skill and `scripts/bench_ab.R` used to find/validate this are in #492 (separate PR).
- Commits 1–3 could be merged on their own if you'd prefer to review the two accuracy changes (4–5) separately.
