### PR TITLE
Floor resource spline at 0 (#253) and keep largest size bracket in interpolate_to_heights (#352)

### DIFF
--- a/R/tidy_outputs.R
+++ b/R/tidy_outputs.R
@@ -136,14 +136,12 @@ interpolate_to_times <- function(tidy_species_data, times, method="natural") {
 #' @importFrom stats spline
 #' @importFrom rlang .data
 interpolate_to_heights <- function(tidy_species_data, heights, method="natural", min_log_density = -100) {
-  
-  # helper function - predicts to new values with spline
-  # only needed to ensure predictions for xout outside the ange of x are set to NA
-  f <- function(x, y, xout, time) {
 
+  # helper function - predicts to new values with spline
+  # values for xout outside the range of x are set to NA (and dropped below)
+  f <- function(x, y, xout) {
     y_pred <- stats::spline(x, y, xout=xout, method=method)$y
     y_pred[!dplyr::between(xout, min(x), max(x))] <- NA
-
     y_pred
   }
 
@@ -151,21 +149,36 @@ interpolate_to_heights <- function(tidy_species_data, heights, method="natural",
     tidy_species_data <- tidy_species_data %>%
       tibble::add_column(step = NA)
   }
-  
-  tidy_species_data %>%
+
+  prepared <- tidy_species_data %>%
     tidyr::drop_na(-dplyr::any_of("step")) %>%
-    
     # check for very negative values
     dplyr::mutate(
       log_density = ifelse(.data$log_density < min_log_density, min_log_density, .data$log_density)
     ) %>%
     dplyr::group_by(.data$species, .data$time, .data$step) %>%
-    # remove any repated x values - these cuase warnings in the interpolation
-    dplyr::filter(!duplicated(.data$height)) %>%
+    # remove any repeated x values - these cause warnings in the interpolation
+    dplyr::filter(!duplicated(.data$height))
 
+  # interpolate each state onto the requested heights; grid points outside the
+  # observed range interpolate to NA and are dropped
+  interpolated <- prepared %>%
     dplyr::reframe(
-      dplyr::across(tidyselect::where(is.double), ~ f(.data$height, .x, xout = heights, .data$time[1]))
+      dplyr::across(tidyselect::where(is.double), ~ f(.data$height, .x, xout = heights))
     ) %>%
+    tidyr::drop_na(dplyr::any_of("height"))
+
+  # On a coarse grid the tallest node usually sits above the highest in-range
+  # grid point, so it would be dropped and the largest size bracket lost.
+  # Append the actual largest individual in each time step instead, rather than
+  # misrepresenting its density at the highest interpolation point (#352).
+  largest <- prepared %>%
+    dplyr::filter(.data$height == max(.data$height)) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(dplyr::any_of(names(interpolated)))
+
+  dplyr::bind_rows(interpolated, largest) %>%
+    dplyr::arrange(.data$species, .data$time, .data$step, .data$height) %>%
     dplyr::mutate(density = exp(.data$log_density))
 }
 

--- a/inst/include/plant/resource_spline.h
+++ b/inst/include/plant/resource_spline.h
@@ -7,6 +7,7 @@
 #include <plant/adaptive_interpolator.h>
 #include <plant/ode_solver/ode_interface.h>
 #include <plant/util.h>
+#include <algorithm> // std::max, for the resource-availability floor (#253)
 
 using namespace Rcpp;
 
@@ -75,8 +76,16 @@ public:
     // `cap` already guards the upper bound and the crown integral keeps
     // height >= 0 = spline.min(), so use the unchecked operator() rather than
     // eval() to avoid re-running check_active()/bound checks per quadrature
-    // point. Same underlying tk_spline(height) call, so bit-identical.
-    return height <= cap ? spline(height) : 1.0;
+    // point. Same underlying tk_spline(height) call.
+    //
+    // Floor the result at 0 (#253): the cubic spline can undershoot below
+    // zero between knots (notably the K93 light spline at high k_I), which is
+    // non-physical for a resource availability. The clamp is a no-op for the
+    // usual positive case (so values stay bit-identical there) and only bites
+    // on the spurious negative undershoot. This is the single chokepoint for
+    // FF16/K93/TF24, and belongs here in plant rather than in the
+    // general-purpose interpolator (which is migrating to odelia).
+    return height <= cap ? std::max(0.0, spline(height)) : 1.0;
   }
 
   virtual void r_init_interpolators(const std::vector<double>& state) {

--- a/tests/testthat/test-environment.R
+++ b/tests/testthat/test-environment.R
@@ -41,3 +41,29 @@ for (x in names(strategy_types)) {
     expect_identical(sapply(hmid, env$light_availability$spline$eval), sapply(hmid, interplator$eval))
   })
 }
+
+test_that("resource spline value is floored at zero (#253)", {
+  # The cubic light spline can undershoot below zero between knots (notably the
+  # K93 light availability at high k_I: a sharp Beer's-law drop to a low, flat
+  # value). Build such a spline directly and confirm that
+  # ResourceSpline::get_value_at_height never returns a negative resource
+  # availability, while staying a no-op wherever the spline is non-negative.
+  env <- Environment("K93")
+
+  hh <- c(0, 1, 2, 3, 4, 5)
+  ee <- c(1, 1, 1, 0.02, 0.02, 0.02)
+  ip <- Interpolator()
+  ip$init(hh, ee)
+  env$light_availability$spline <- ip
+
+  grid    <- seq(0, 5, by = 0.05)
+  raw     <- vapply(grid, ip$eval, numeric(1))
+  floored <- vapply(grid, env$light_availability$get_value_at_height, numeric(1))
+
+  # the scenario genuinely undershoots, otherwise the test proves nothing
+  expect_true(any(raw < 0))
+  # ... but the accessor never returns a negative value ...
+  expect_true(all(floored >= 0))
+  # ... and is bit-identical wherever the raw spline is non-negative
+  expect_equal(floored, pmax(0, raw))
+})

--- a/tests/testthat/test-tidy-outputs.R
+++ b/tests/testthat/test-tidy-outputs.R
@@ -138,7 +138,7 @@ test_that("interpolate_to_times recovers known values and NAs out-of-range", {
   expect_true(all(is.na(out_oor$height)))
 })
 
-test_that("interpolate_to_heights recovers known values, rebuilds density, NAs out-of-range", {
+test_that("interpolate_to_heights recovers known values, rebuilds density, appends largest node", {
   # leaf_area linear in height (10*h) and log_density linear (-(h-1)).
   df <- tibble::tibble(
     species     = 1,
@@ -148,13 +148,38 @@ test_that("interpolate_to_heights recovers known values, rebuilds density, NAs o
     leaf_area   = c(10, 20, 30)
   )
 
+  # interpolated grid points, plus the largest individual (height 3) appended
+  # rather than dropped (#352)
   out <- interpolate_to_heights(df, heights = c(1.5, 2.5))
-  expect_equal(out$leaf_area, c(15, 25))
-  expect_equal(out$log_density, c(-0.5, -1.5))
+  expect_equal(out$height, c(1.5, 2.5, 3))
+  expect_equal(out$leaf_area, c(15, 25, 30))
+  expect_equal(out$log_density, c(-0.5, -1.5, -2))
   # density is rebuilt as exp(log_density)
-  expect_equal(out$density, exp(c(-0.5, -1.5)))
+  expect_equal(out$density, exp(c(-0.5, -1.5, -2)))
 
-  # heights outside the observed range return NA
+  # grid points outside the observed range are dropped, but the largest
+  # individual is still retained rather than discarded (#352)
   out_oor <- interpolate_to_heights(df, heights = c(0, 5))
-  expect_true(all(is.na(out_oor$leaf_area)))
+  expect_equal(out_oor$height, 3)
+  expect_equal(out_oor$leaf_area, 30)
+})
+
+test_that("interpolate_to_heights retains the largest size bracket on a coarse grid (#352)", {
+  # reprex from the issue: tallest node (3.3) sits above the highest in-range
+  # grid point (3), so the coarse grid would otherwise drop the largest class.
+  data <- tibble::tibble(
+    step        = 1,
+    species     = 1,
+    time        = 10,
+    height      = c(0.1, 1.2, 2.3, 3.3),
+    log_density = log(c(0.1, 0.1, 0.1, 0.2))
+  )
+
+  out <- interpolate_to_heights(data, heights = 1:4)
+  # the actual largest individual is kept ...
+  expect_true(3.3 %in% out$height)
+  # ... the out-of-range grid point (4, above 3.3) is dropped ...
+  expect_false(any(out$height == 4))
+  # ... and no node is silently lost to NA
+  expect_false(anyNA(out$height))
 })


### PR DESCRIPTION
Fixes two long-standing issues, verified against the current code during an issue review.

## #253 — resource spline can return negative values
`Interpolator`/`AdaptiveInterpolator` only validate the x-domain, never the y-result, so the cubic spline can undershoot below zero between knots — notably the **K93 light spline at high `k_I`**, the exact case the issue raised. The `<= 0 → 0` guard added in #490 is FF16-only and only on the PPA stepped-light path; the smooth/default path and K93/TF24 passed negatives straight through.

**Fix:** floor the result at zero at the single shared consumer chokepoint `ResourceSpline::get_value_at_height` (`inst/include/plant/resource_spline.h`), covering FF16/K93/TF24 at once:

```cpp
return height <= cap ? std::max(0.0, spline(height)) : 1.0;
```

The clamp is a no-op for the usual positive case (values stay bit-identical there) and only bites on the spurious negative undershoot.

**Why here and not odelia:** the `Interpolator` class is migrating to the general-purpose `odelia` package (#464/#456), but "resource availability ≥ 0" is a plant-domain assumption, not a property of cubic interpolation, so the clamp belongs in plant's consumer layer. `resource_spline.h` is unchanged by the migration, so this is migration-proof.

## #352 — `interpolate_to_heights` drops the largest size bracket
On a coarse grid, grid points above the tallest node interpolate to `NA`, so individuals in the largest size class were silently dropped (PR #437 only touched error checking).

**Fix** (`R/tidy_outputs.R`): drop the out-of-range grid points and **append the actual largest individual in each time step**, rather than misrepresenting its density at the highest interpolation point — matching the behaviour requested in the issue.

## Tests
- Updated the `interpolate_to_heights` test that pinned the old drop-behaviour.
- Added a regression test using the issue's exact reprex.
- Targeted suites all pass (0 failures, 0 warnings): `tidy-outputs`, `environment`, `environment-TF24`, `strategy-{ff16,k93,tf24}`, `scm`, `patch`, `node`, stochastic patch runners.

Closes #253
Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)