### PR TITLE
Use string column names in tidyselect contexts (closes #375)

### DIFF
--- a/R/tidy_outputs.R
+++ b/R/tidy_outputs.R
@@ -225,7 +225,7 @@ integrate_over_size_distribution <- function(tidy_species_data) {
     dplyr::reframe(
       density_integrated = -trapezium(.data$height, .data$density), 
       min_height = min(.data$height),
-      dplyr::across(tidyselect::where(is.double) & !c(.data$density, .data$density_integrated, .data$min_height) , ~-trapezium(height, density * .x)) 
-    ) %>% 
-    dplyr::rename(density = .data$density_integrated)
+      dplyr::across(tidyselect::where(is.double) & !c("density", "density_integrated", "min_height") , ~-trapezium(height, density * .x))
+    ) %>%
+    dplyr::rename(density = "density_integrated")
 }


### PR DESCRIPTION
Closes #375.

tidyselect 1.2.0 deprecated `.data$` inside **tidyselect** expressions, which produced the `dplyr::reframe()` / `dplyr::across()` warnings reported in the issue.

The issue suggested searching for `.data$` and removing it wholesale, but that would be wrong: the deprecation applies only to tidyselect contexts, not data-masking ones. Of the ~50 `.data$` uses in the package, only two were genuinely deprecated — both in `integrate_over_size_distribution()`:

- `!c(.data$density, .data$density_integrated, .data$min_height)` → `!c("density", "density_integrated", "min_height")` (selection part of `across()`)
- `dplyr::rename(density = .data$density_integrated)` → `dplyr::rename(density = "density_integrated")` (rename RHS)

All other `.data$` uses (in `mutate` / `filter` / `group_by` / `summarise` / `ggplot2::aes`) are data-masking and remain correct, so they are left unchanged.

## Testing

`test-tidy-outputs.R`: `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 58 ]` — passes with no warnings (this path previously emitted the tidyselect deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)