### PR TITLE
Add plant-update-interface skill; backfill NEWS; rename new-strategy skill

### DIFF
--- a/.claude/skills/plant-new-strategy/SKILL.md
+++ b/.claude/skills/plant-new-strategy/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: new-strategy
+name: plant-new-strategy
 description: >-
   Scaffold a new strategy (and optionally environment) model in the plant
   C++/R package, then wire it through the build. Use when asked to add a new

--- a/.claude/skills/plant-new-strategy/worked-example-k93.md
+++ b/.claude/skills/plant-new-strategy/worked-example-k93.md
@@ -1,6 +1,6 @@
 # Worked example: implementing Kohyama 1993 (K93) as a new strategy
 
-This is the reference walkthrough for the **biology** step of `new-strategy`
+This is the reference walkthrough for the **biology** step of `plant-new-strategy`
 (originally `vignettes/strategy_new.Rmd`). It shows how the shipped K93 model was
 built by scaffolding from FF16 and then filling in a simple size-structured
 model. K93 already exists in the package — read its files

--- a/.claude/skills/plant-update-interface/SKILL.md
+++ b/.claude/skills/plant-update-interface/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: plant-update-interface
+description: >-
+  Migrate code that uses the plant R package up to plant's latest interface.
+  Use when a downstream product (analysis scripts, a dependent package, a
+  notebook) breaks or needs updating after plant changed — e.g. "update X to the
+  latest plant", "plant's interface changed, fix my code", "migrate to the new
+  run_scm/Control API", "bring this repo up to date with plant". Reads plant's
+  NEWS.md "Breaking changes" as the spec, finds affected call sites, and
+  proposes per-site fixes. Does NOT change plant itself or invent API mappings —
+  if NEWS lacks a needed mapping, it stops and asks.
+---
+
+# Updating products to plant's latest interface
+
+plant's R-facing interface changes as the package develops (the SCM
+consolidation, the `Control()` defaults, the odelia split, …). Downstream
+code — analysis repos, dependent packages, notebooks — breaks when symbols are
+renamed, removed, or change meaning. This skill migrates that downstream code.
+
+**The contract this skill works under:**
+
+- **`NEWS.md` is the spec, not this file.** plant's `NEWS.md` "Breaking changes"
+  section holds the canonical `old -> new` mappings, written to be machine-read.
+  This skill is the *applier*: it reads NEWS each run, so it keeps working as
+  plant adds changes without this file having to be updated. **Never migrate
+  from a mapping memorised here or from training data** — always read the live
+  NEWS. If a breakage has no mapping in NEWS, stop and ask the maintainer rather
+  than guessing.
+- **Propose, don't blind-apply.** Show the diff for each call site. Mechanical
+  renames can be applied directly; semantic changes (an argument's meaning
+  flipped, a default changed) must be flagged for human review.
+- **This runs in the *product* repo, not in plant.** It edits the downstream
+  code. It only *reads* plant (its NEWS, optionally its installed source).
+
+## Step 1 — locate the authoritative NEWS.md
+
+Resolve plant's NEWS in this order; stop at the first that works:
+
+1. **Working inside the plant repo itself?** (`./DESCRIPTION` has
+   `Package: plant`) → use `./NEWS.md`.
+2. **Latest from GitHub** (the usual case — migrating a separate product to the
+   newest plant):
+   ```sh
+   curl -fsSL https://raw.githubusercontent.com/traitecoevo/plant/develop/NEWS.md
+   ```
+   Pin to a tag/branch the product is targeting if one is known
+   (`.../plant/<ref>/NEWS.md`).
+3. **Installed package** (offline / matching what's actually loaded):
+   ```r
+   system.file("NEWS.md", package = "plant")   # or: utils::news(package = "plant")
+   ```
+
+Read the whole **"Plant (development version)"** block — at minimum its
+"Breaking changes" subsection, plus "New features" (a product may want to adopt
+one, e.g. `export_patch_state()` or `control$shading_model`).
+
+## Step 2 — determine the product's baseline
+
+You need to know which changes are *new to this product*, so you don't re-apply
+ones already done.
+
+- **Marker file** (preferred): look for `.plant-interface-version` at the product
+  root. The skill writes it at the end of a successful run, recording the date
+  and the list of breaking-change keys already applied. If present, only entries
+  **not** in it are in scope.
+- **No marker?** Fall back to the installed `packageVersion("plant")` and/or ask
+  the maintainer "which plant version did this last work against?". The plant
+  dev version doesn't bump per-change, so version numbers are coarse — when in
+  doubt, treat the *entire* current "Breaking changes" section as candidate work
+  and let Step 4's grep tell you what actually applies (a no-match symbol is
+  simply already-clean).
+
+## Step 3 — build the migration map from NEWS
+
+From the in-scope "Breaking changes" entries, extract each `old -> new` mapping.
+Classify each:
+
+- **Mechanical rename** — a 1:1 symbol or simple-arg substitution
+  (e.g. `fast_control()` -> `control()`). Safe to apply across all matches.
+- **Semantic change** — same symbol, changed meaning/default, or a multi-step
+  replacement (e.g. raw `Control()` now means *fast* not *accurate*; the
+  `run_scm()` argument-order change; `run_scm_error()` -> set a field then read
+  another). These need per-site judgement — never sed blindly.
+
+If an entry's mapping is ambiguous or missing, **stop and ask** — do not invent
+one. That gap is a NEWS bug; note it so it can be fixed at the source.
+
+## Step 4 — find the call sites
+
+Grep the product for every affected symbol. Search R sources, scripts, vignettes
+/ Quarto / Rmd, tests, and roxygen examples:
+
+```sh
+grep -rn --include='*.R' --include='*.r' --include='*.Rmd' --include='*.qmd' \
+  -e 'run_scm_collect' -e 'run_scm_error' -e 'build_schedule' -e 'split_times' \
+  -e 'fast_control' -e 'scm_base_control' -e '\brun_scm\b' -e '\bControl\b' \
+  -e 'OdeRunner' .
+```
+
+**Known affected symbols as of 2026-06** (operational grep list — *reconcile
+against the live NEWS Breaking changes section, which is canonical; add any
+symbol it lists that isn't here, and don't trust this list if NEWS is newer*):
+
+| Symbol to grep | Kind | See NEWS entry |
+|---|---|---|
+| `run_scm_collect`, `run_scm_error`, `build_schedule`, `split_times` | removed → `run_scm()` flags | SCM consolidation (#408/#459/#462) |
+| `run_scm(` (positional args) | arg-order change | SCM consolidation |
+| `fast_control`, `scm_base_control` | removed → `control()` / `control_accurate()` | Control defaults (#463) |
+| `Control(` / `control(` used expecting *accurate* tolerances | semantic: now fast | Control defaults (#463) |
+| `OdeRunner`, plant ODE/interpolator C++ headers | moved to odelia | odelia split (#456/#464) |
+
+Also grep `NAMESPACE` / `DESCRIPTION` `Imports`/`importFrom` if the product is a
+package, and any `library(plant)` / `plant::` qualified calls.
+
+## Step 5 — apply the migrations
+
+Per call site, smallest faithful edit, in the product's own style:
+
+- **Mechanical renames:** apply directly. Show a summary diff.
+- **Semantic changes:** present the before/after for the maintainer. Examples:
+  - A bare `Control()` / `scm_base_control()` that fed a *high-accuracy* run must
+    become `control_accurate()`, not `control()` — you cannot tell which was
+    intended from the call alone, so ask or flag.
+  - `run_scm(p, env, ctrl, use_ode_times = TRUE)` written positionally may now
+    bind `use_ode_times` to the wrong parameter — rewrite with named arguments.
+  - `run_scm_error()` becomes a two-step (`scm$collect_errors <- TRUE`; read
+    `scm$combined_node_errors`) — restructure, don't substitute.
+- Leave a brief `# plant N.N migration: …` comment only where the change is
+  non-obvious; don't litter.
+
+## Step 6 — rebuild, test, record
+
+Run the **product's own** verification (not plant's):
+
+- Package → `devtools::load_all()` then `devtools::test()` (or `R CMD check`).
+- Scripts / notebooks → execute the affected ones end-to-end.
+- Re-grep the removed symbols to confirm none remain (except in NEWS/changelog
+  prose).
+
+Then update the baseline marker so the next run is incremental:
+
+```r
+# .plant-interface-version (product root) — written after a clean migration
+writeLines(c(
+  "migrated_on: 2026-06-23",
+  "plant_ref: develop@<sha or tag>",
+  "applied_breaking_changes:",
+  "  - scm-consolidation",
+  "  - control-defaults",
+  "  - odelia-split"
+), ".plant-interface-version")
+```
+
+Report what changed, what was applied mechanically vs. flagged for review, and
+anything that couldn't be migrated because NEWS lacked a mapping.
+
+## Verification checklist
+
+- Migration mappings came from the **live NEWS**, not memory — and every applied
+  change traces to a NEWS "Breaking changes" entry.
+- No removed symbol remains in the product's executable code.
+- Semantic changes (accurate-vs-fast `Control`, `run_scm` arg order) were
+  surfaced for review, not silently rewritten.
+- The product's own tests / scripts pass after migration.
+- `.plant-interface-version` records the new baseline.
+- Any missing/ambiguous NEWS mapping was reported (so plant's NEWS can be fixed).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,17 +2,149 @@
 
 ### Breaking changes
 
+These change the R-facing interface and require updating downstream code. Each
+entry gives the `old -> new` migration; the `plant-update-interface` skill
+(`.claude/skills/plant-update-interface/`) reads this section to migrate
+products using plant.
+
 * SCM cohort-refinement now happens entirely in C++, and the R interface is
   consolidated onto a single `run_scm()`. `run_scm_collect()`, `run_scm_error()`
-  and `build_schedule()` have been removed (#408, #459). Migration:
-  * `build_schedule(p, …)` -> `run_scm(p, …, refine_schedule = TRUE)$parameters`
+  and `build_schedule()` have been removed (#408, #459, #462). Migration:
+  * `build_schedule(p, …)` -> `scm <- run_scm(p, …, refine_schedule = TRUE)`,
+    then read the refined parameters as `scm$parameters`. The former
+    `attr(p_new, "offspring_production")` side-channel is now
+    `scm$offspring_production`.
   * `run_scm_collect(p, …)` -> `run_scm(p, …, collect = TRUE)`
   * `run_scm_error(p, …)` -> set `scm$collect_errors <- TRUE` then read
     `scm$combined_node_errors`
 * The argument order of `run_scm()` changed; `use_ode_times` is now the last
   argument (after the new `refine_schedule` and `collect`).
+* Numeric `Control` defaults are now set in the C++ `Control()` constructor
+  (the pragmatic "fast" settings), and the two R preset helpers were removed
+  (#463). Raw `Control()` now means **fast**, not accurate. Migration:
+  * `fast_control()` -> `Control()` (or its lowercase alias `control()`)
+  * `scm_base_control()` -> `Control()` / `control()`
+  * for the old tight-tolerance behaviour -> `control_accurate()`
+  * `scm_base_parameters()` is unaffected (it builds a `Parameters`, not a
+    `Control`).
+* The ODE solver and interpolator core were spun out into the standalone
+  [odelia](https://github.com/traitecoevo/odelia) package, which plant now
+  depends on (#456, #464). Plant's internal solver/interpolator headers
+  (`inst/include/plant/ode_solver/*`, `interpolator.*`, `tk_spline.*`) were
+  removed in favour of `odelia::ode::Solver` / `odelia/interpolator.hpp`.
+  Migration: code that linked against plant's C++ numerics headers, or used the
+  old `OdeRunner`/interpolator R6 types directly, must switch to odelia. Pure-R
+  callers of `run_scm()` / `run_stochastic()` are unaffected.
 
-### Minor changes / internals
+The following earlier changes (since the 2.0.0 release) are also breaking and
+were not previously recorded here:
+
+* All fitness/equilibrium functionality was removed from plant; it now lives in
+  the separate `plant.assembly` package (#388). Removed `fitness_landscape()`,
+  `solve_max_fitness()`, `viable_fitness()`, `fundamental_fitness()`,
+  `assembly_parameters()`, `equilibrium_birth_rate()` and the `equilibrium_*`
+  parameters/controls.
+* The `Environment` object was removed from `Parameters`; pass it directly as
+  the `env` argument to run functions, e.g.
+  `run_scm(p, env = Environment("FF16"))` (#315). Likewise `Control` was removed
+  from `Parameters` and is passed as the `ctrl` argument (#314).
+* SCM & environment interface simplified (#446): environment construction is now
+  the single `Environment("FF16")` constructor — removed `make_environment()`,
+  `FF16_make_environment()`, `FF16_fixed_environment()`, `test_environment()`,
+  and the helpers `scm_patch()`, `make_scm_integrate()`, `scm_state()`,
+  `patch_to_internals()`, `scm_to_internals()`, `species_to_internals()`,
+  `first()`, `last()`, `modify_list()`. State collection moved to C++ and
+  `tidy_patch` runs by default.
+* Node/Species/SCM competition methods renamed (#448):
+  * `Species$competition_effects` -> `Species$compute_competition_effect_by_nodes`
+  * `Species$competition_effects_error` -> `Species$compute_competition_effect_by_nodes_error`
+  * `SCM$competition_effect_error` -> `SCM$compute_competition_effect_error_by_node_for_species_i`
+  * the `Node$competition_effect` getter was removed.
+* The exported-function surface was reduced (#420): the per-model R6 generators
+  (`FF16_*`, `K93_*`, `TF24_*` `Node`/`Patch`/`SCM`/`Species`/`Stochastic*`) and
+  many utilities (`Internals`, `OdeControl`, `bounds`, `check_bounds`,
+  `clamp_domain`, `nlsolve`, `splinefun_log`/`splinefun_loglog`, `strategy`,
+  `strategy_default`, `validate`, …) are no longer exported. Rename:
+  `make_transparent()` -> `util_colour_set_opacity()`.
+* The `Cohort` class/concept was renamed `Node` throughout — classes, methods,
+  filenames, and R-side `coh` variables (#335).
+* "Seed rain" terminology renamed for clarity (#297):
+  * `seed_rain[_in]` -> `birth_rate`
+  * `seed_rain[_out]` -> `net_reproduction_ratio` / `offspring_production`
+  * `add_seeds()` -> `introduce_new_cohort()`
+* Canopy/light renamed and generalised (#384): the `canopy` class became
+  `Resource_spline` (`canopy.h` -> `resource_spline.h`); `compute_canopy` ->
+  `light_availability$compute_environment`; `canopy_light_*` controls ->
+  `light_availability_spline_*`; `get_canopy_at_height()` / `canopy_openness()`
+  -> `get_value_at_height()`. The standalone `assimilation` class and its
+  adaptive-integration options were removed.
+* Extrinsic-driver API reworked (#340): per-driver `Environment` methods replaced
+  by an `ExtrinsicDrivers` object at `env$extrinsic_drivers`, with
+  `evaluate("rainfall", t)` / `evaluate_range("rainfall", c(...))`.
+* ODE-stepper methods renamed (#413): `advance()` -> `advance_adaptive()`;
+  `node_schedule_ode_times()` -> `ode_times()`. The corresponding `Parameters`
+  field was also renamed: `p$node_schedule_ode_times` -> `p$ode_times`.
+* Growth-optimisation routine generalised (#382):
+  `FF16_solve_max_size_growth_rate_at_height()` ->
+  `optimise_individual_rate_at_size_by_trait()` (new `size` / `size_name` args),
+  with a height wrapper `optimise_individual_rate_at_height_by_trait()`.
+* Removed the `FF16w` strategy, superseded by TF24 (`FF16w` -> `TF24`) (#438),
+  and the `FF16r` strategy (#439); removed the experimental soil component from
+  `FF16` (#441).
+* Replaced the Leaf cost parameter `g1_TF24` with the Medlyn stomatal-conductance
+  parameters `g0` (default 0.022) and `g1` (default 2.57) on the TF24 `Leaf`
+  (#450, #451).
+* `Disturbance` refactored into a `Disturbance_Regime` base with
+  `No_Disturbance_Regime` / `Weibull_Disturbance_Regime` subclasses (#301);
+  disturbance configuration moved from `Environment` to `Patch` (#290); the
+  light-extinction coefficient `k_I` moved from `Parameters` onto the strategy
+  (#293, #302).
+
+### New features
+
+* `run_scm()` can start a patch from **pre-existing nodes** rather than always
+  growing from empty — to resume an exported run or to seed an arbitrary initial
+  size distribution at patch age 0 (#499, revives #304). New
+  `export_patch_state(scm, step)` captures a patch's full state; the initial
+  condition rides on the `Parameters` object (`initial_state`,
+  `n_initial_cohorts`, …) so `run_scm(p)` just works and stays serialisable.
+* Selectable **canopy shading models** for FF16/TF24 via `control$shading_model`
+  (#490, #417): `""` (each strategy's own default), `deep-crown`, `mean-light`,
+  `crown-centre`, `flat-top-soft-box`, `flat-top-box`, `ppa` (with
+  `ppa_layer_optical_depth` / `ppa_layer_smoothing`). Dispatch is bound once in
+  `prepare_strategy()`; deep-crown is bit-for-bit unchanged.
+* Alternative **fixed-step forward-Euler** ODE integration alongside the
+  adaptive Cash-Karp solver, selected with `control$fixed_time_step` (years;
+  `0` = adaptive RKCK, the default) (#489). Combining `fixed_time_step > 0`
+  with a mutant run / `save_RK45_cache` / `use_ode_times` errors clearly.
+* Multi-layer **root water uptake** for the TF24 strategy (soil→root→stem→leaf
+  hydraulic pathway following Potkay et al. 2021), replacing the previous
+  single-value soil-water treatment (#488).
+* Added the **TF24 strategy** — a leaf-level water-use/hydraulics model with a
+  `TF24_Environment` whose soil-layer count and parameters can be set after
+  construction (#445), including a Medlyn stomatal-conductance model on the leaf
+  (`solve_medlyn_ci_*`, `medlyn_model_gs`) (#450).
+* New **mutant-fitness method**: caches resident environments at each ODE step so
+  mutant fitness reuses the residents' resource shadow. Adds a `save_history` /
+  `save_RK45_cache` control, `environment_history` / `patch_step_history` on the
+  SCM, and a `mutant_parameters()` method (#362, #379).
+* Per-species **time-varying birth rates** via the extrinsic-driver mechanism:
+  `set_constant_birth_rate(p, i, k)`, `set_interpolated_birth_rate(p, i, x, y)`,
+  and `Parameters` fields `birth_rate_x` / `birth_rate_y` /
+  `is_constant_birth_rate` (#334).
+* `run_scm()` collected output now exports the extrinsic environment drivers per
+  timestep (`out$env[[t]]$canopy`, `…$rainfall`); new drivers export
+  automatically (#347).
+* `expand_state()` generalised to apply to any strategy (#443).
+* New strategy parameter `recruitment_decay` — exponential decline of
+  establishment probability with patch age (#330).
+* Per-individual `consumption_rates` (water extraction across cohorts/soil
+  layers) feeding the water-enabled environment's soil balance (#329); FF16
+  rainfall getters/setters + spline exposed to R (#324); environment auxiliary
+  variables (#323) and environment state variables (#305) exposed/added.
+* Added an HTML report (plots + analyses) for the FF16 strategy (#350).
+
+### Minor changes & bug fixes
 
 * `Node` now records its introduction time and patch-age density at the moment
   it is introduced, so reproduction and integration-error calculations no longer
@@ -20,6 +152,44 @@
 * `SCM::run()` accumulates the per-node refinement error when `collect_errors`
   is set, exposed as `combined_node_errors`; `SCM::refine_schedule()` runs the
   adaptive node-introduction loop in C++.
+* The resource spline is now floored at 0, fixing spurious negative light
+  values (notably the K93 light spline at high `k_I`) (#253, #497).
+* `interpolate_to_heights()` no longer silently drops individuals in the largest
+  size class on a coarse grid; it appends the actual largest individual per time
+  step instead (#352, #497).
+* Fixed `tidyselect` deprecation warnings from `integrate_over_size_distribution()`
+  by using string column names in `across()`/`rename()` selection contexts
+  (#375, #501).
+* Account for variable patch size in light/competition calculations (#422).
+* Fixed the argument order in `net_mass_production_dt()` (#389).
+* Fixed integration of density (#345).
+* Fixed `scm_support` to use the correct error name `net_reproduction_ratio_errors`
+  and guard the zero-offspring case (#447).
+* The ODE solver now continues when the minimum step size is reached (#413);
+  refined the `interpolate_to_heights()` error check (#437).
+
+### Internals & performance
+
+* Hot-path optimisation of FF16/TF24 (~2.7–3.5× FF16, ~1.3× TF24) (#471), K93
+  SCM perf (#493), and shared `pow(area_leaf, a_l2)` in FF16 `compute_rates`
+  (#361, #494). See the `profile-plant` skill for the methodology.
+* Earlier internals (since 2.0.0): default compilation set to `-O2` (#365);
+  assimilation decoupled into a per-strategy `Assimilator` (#313); extrinsic
+  drivers refactored into an `ExtrinsicDrivers` class (#334, #340); test-only
+  reference plant relocated into the tests (#418); unused logging removed (#436);
+  Makefile dev-loop speedups (#319); general `R CMD check` cleanup (#440).
+
+### Documentation & tooling
+
+* Narrative docs (former `vignettes/`, theory, dated posts) migrated to the
+  [Overstorey](https://traitecoevo.github.io/overstorey/) site; the pkgdown
+  site is now the function reference only (#496).
+* The strategy-scaffolder workflow and a profiling workflow are now captured
+  as the `plant-new-strategy` and `profile-plant` skills (#495, #492).
+* Relicensed from GPL-2 to **AGPL-3** (#457).
+* Upgraded the minimum C++ standard from C++14 — currently C++20 (#442).
+* Expanded the K93 (#421) and self-thinning (#369) vignettes; added a draft
+  `extrinsic_drivers` vignette (#340).
 
 ## Plant 2.0.0 release notes
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The narrative documentation — user guides, theory, and worked examples — now
 
 Plant is a complex package, using [C++20](https://en.wikipedia.org/wiki/C%2B%2B20) behind the scenes for speed with [R6 classes](https://cran.r-project.org/web/packages/R6/vignettes/Introduction.html) (via the [Rcpp](https://cran.r-project.org/web/packages/Rcpp/index.html) and [RcppR6](https://github.com/richfitz/RcppR6) packages).  In this blog post, Rich FitzJohn and I describe the [key technologies used to build the plant package](https://methodsblog.wordpress.com/2016/02/23/plant/). 
 
-If you are interested in developing or extending plant, start with [agents.md](agents.md), which documents the package architecture, the C++/R interface, the build workflow, and how to add a new model. The `new-strategy` skill (`.claude/skills/new-strategy/`) walks through scaffolding and implementing a new strategy.
+If you are interested in developing or extending plant, start with [agents.md](agents.md), which documents the package architecture, the C++/R interface, the build workflow, and how to add a new model. The `plant-new-strategy` skill (`.claude/skills/plant-new-strategy/`) walks through scaffolding and implementing a new strategy.
 
 ## Installation
 
@@ -101,7 +101,7 @@ p <- expand_parameters(trait_matrix(0.0825, "lma"), p)
 results <- run_scm_collect(p)
 ```
 
-If you want to develop or extend `plant` (e.g. add a new strategy/model), see [agents.md](agents.md) and the `new-strategy` skill (`.claude/skills/new-strategy/`).
+If you want to develop or extend `plant` (e.g. add a new strategy/model), see [agents.md](agents.md) and the `plant-new-strategy` skill (`.claude/skills/plant-new-strategy/`).
 
 ## Benchmarking
 

--- a/agents.md
+++ b/agents.md
@@ -196,6 +196,62 @@ What moved into C++ (all on `Node`/`Species`/`SCM` in
 **Known downstream breakage:** `plant.assembly` calls the removed functions in
 `R/community_plant.R` and `scripts/example/ESA.Rmd`; update per the table above.
 
+### 3.3 When you change the R-facing interface — record it for downstream migration
+
+Renaming, removing, or changing the meaning of anything a user calls (functions,
+arguments, argument order, `Control`/`Parameters` fields, R6 types) breaks
+downstream products (analysis repos, `plant.assembly`, notebooks). Two
+obligations whenever you make such a change:
+
+1. **Record an `old -> new` mapping in [NEWS.md](NEWS.md)** under the development
+   version's **"Breaking changes"** subsection. Write it to be *machine-actionable*
+   — explicit `old(...)` -> `new(...)` lines, one per affected symbol, the way
+   §3.1/§3.2's tables and the existing NEWS entries are. This section is the
+   single source of truth for migration; agents.md narrates the *why*, NEWS
+   carries the *exactly what changed*. Pure-internal/perf changes go under
+   "Internals & performance" instead and need no migration line.
+2. **Downstream migration is a skill, not a manual chase.** The
+   **`plant-update-interface` skill** (`.claude/skills/plant-update-interface/`)
+   reads NEWS's "Breaking changes" entries and applies them to a product repo
+   (locate call sites, propose per-site fixes, rebuild + test, record a baseline
+   marker). It does *not* memorise the API — it re-reads NEWS each run — so the
+   only thing that keeps it working is keeping NEWS disciplined per (1). To bring
+   a product up to date, run that skill *in the product repo*. If you find a
+   breaking change with no NEWS mapping, that's a NEWS bug — fix it at the source.
+
+#### How to write a Breaking-changes entry (format the skill can act on)
+
+The migration skill reads these entries mechanically, so the format matters as
+much as the prose. Rules:
+
+- **One bullet per change; PR number(s) at the end** in parens, e.g. `(#463)`.
+- **State the `old -> new` mapping explicitly**, with the call form, not just the
+  name. `run_scm_collect(p, …) -> run_scm(p, …, collect = TRUE)` is actionable;
+  "consolidated the SCM interface" is not.
+- **One sub-bullet per affected symbol** when a change touches several:
+  ```markdown
+  * <one-line what-and-why> (#NNN). Migration:
+    * `old_fn(a, b)`            -> `new_fn(a, b, flag = TRUE)`
+    * `old_field`               -> `obj$new_field`
+    * `helper()` (removed)      -> `<replacement, or "no equivalent">`
+  ```
+- **Capture side-channels, not just the renamed call.** If callers read a result
+  via an attribute, a returned list element, or a follow-up getter, map *that*
+  too — a name-only mapping silently drops it. (Real example: `build_schedule()`
+  returned its result with `attr(., "offspring_production")`; the faithful
+  migration is `scm <- run_scm(p, refine_schedule = TRUE); scm$parameters;
+  scm$offspring_production` — the `$parameters`-only mapping loses the
+  offspring count.)
+- **Flag semantic (not mechanical) changes loudly.** A symbol whose *meaning* or
+  *default* changed while its name stayed the same (e.g. raw `Control()` now
+  means *fast*, not accurate) must say so in words — the skill cannot infer it
+  from a grep and will (correctly) escalate it for human review.
+- **Argument-order / signature changes** get their own bullet; advise callers to
+  switch to named arguments.
+- For larger reorganisations, also add a narrative subsection here in §3 (as
+  §3.1/§3.2 do) and link it from the NEWS bullet — NEWS carries the *exact what*,
+  agents.md the *why*.
+
 ---
 
 ## 4. The R interface layer
@@ -312,10 +368,10 @@ The scaffolder ([scripts/new_strategy_scaffolder.R](scripts/new_strategy_scaffol
 After scaffolding, implement the biology: growth/mortality/reproduction in the
 new strategy, map `competition_effect` to the environment, wire rates into
 `compute_rates`, and update `state_names()`/`state_size()`. Then run
-`make rebuild` and add tests. The **`new-strategy` skill**
-(`.claude/skills/new-strategy/`) captures the full workflow, including a worked
+`make rebuild` and add tests. The **`plant-new-strategy` skill**
+(`.claude/skills/plant-new-strategy/`) captures the full workflow, including a worked
 walkthrough implementing Kohyama 1993 as K93
-(`.claude/skills/new-strategy/worked-example-k93.md`).
+(`.claude/skills/plant-new-strategy/worked-example-k93.md`).
 
 The three shipped models:
 
@@ -377,7 +433,8 @@ Documentation is split across several homes — put new content in the right one
 |---|---|---|
 | **Narrative docs** — task-oriented guides, theory/maths, worked examples (the former `vignettes/`: `plant` overview, `individuals`, `patch`, `demography`, `parameters`, `extrinsic_drivers`, `emergent`, `self_thinning`) | **[Overstorey](https://traitecoevo.github.io/overstorey/)** | <https://github.com/traitecoevo/overstorey> (Quarto) |
 | **Blog / dated experiments** — posts pinned to the `plant` version they were built against (was `vignettes/blog/`) | Overstorey's **"Adaptively"** notebook | same repo |
-| **Extending the model** — adding a new strategy/environment | **`new-strategy` skill** (see §7) | this repo (`.claude/skills/new-strategy/`) |
+| **Extending the model** — adding a new strategy/environment | **`plant-new-strategy` skill** (see §7) | this repo (`.claude/skills/plant-new-strategy/`) |
+| **Migrating downstream code** to a newer plant interface | **`plant-update-interface` skill** (see §3.3) | this repo (`.claude/skills/plant-update-interface/`) |
 | **Function/API reference** — per-function docs generated from roxygen | **pkgdown site** <https://traitecoevo.github.io/plant/> | this repo (`man/`, `pkgdown/_pkgdown.yml`) |
 | **Architecture / contributor guide** | this file ([agents.md](agents.md)) | this repo |
 | Installation & citation | [README.md](README.md) | this repo |

--- a/scripts/new_strategy_scaffolder.R
+++ b/scripts/new_strategy_scaffolder.R
@@ -4,7 +4,7 @@
 # existing model. This generates the boilerplate C++/R files and wires the new
 # `<Strategy, Environment>` pair into every place the templated core and the R
 # dispatch tables need to learn about it. You still implement the biology by
-# hand afterwards (see the `new-strategy` skill, .claude/skills/new-strategy/).
+# hand afterwards (see the `plant-new-strategy` skill, .claude/skills/plant-new-strategy/).
 #
 # Usage (from the package root):
 #


### PR DESCRIPTION
## Summary

Adds a `plant-update-interface` skill that migrates downstream products (analysis repos, dependent packages, notebooks) up to plant's latest interface, backfills the development-version changelog so the skill has a complete spec to work from, and renames the `new-strategy` skill for a consistent `plant-*` namespace.

## Motivation

plant's R-facing interface changes as it develops, and downstream code breaks. Rather than chase each break by hand, the migration knowledge lives in **one** place (`NEWS.md` "Breaking changes", written as machine-actionable `old -> new` maps) and a thin skill *applies* it — so the skill keeps working as plant evolves, without itself being edited.

## Changes

- **`.claude/skills/plant-update-interface/`** (new) — reads `NEWS.md` "Breaking changes" as the spec, finds call sites in a product repo, proposes per-site fixes (mechanical vs. semantic), rebuilds/tests, and records a `.plant-interface-version` baseline marker. Principle: NEWS is the single source of truth; propose-don't-blind-apply; if a mapping is missing, stop and flag it as a NEWS bug.
- **`NEWS.md`** — restructured the development-version section and backfilled the full v2.0.0→present user-facing changelog: breaking changes (with `old -> new` migration maps), new features, fixes, internals, and docs.
- **`agents.md`** — new §3.3 documenting the discipline (every R-facing change gets an `old -> new` NEWS entry; downstream migration is the skill's job) plus a format spec for writing entries the skill can act on.
- **Renamed `new-strategy` → `plant-new-strategy`** for a consistent `plant-*` skill namespace; updated all references (README, agents.md, scaffolder comment).

## Validation

Test-ran the skill against `plant.assembly`: it located every affected call site, correctly distinguished mechanical renames (`scm_base_control() -> control()`) from semantic changes (the `build_schedule()` site relied on an `attr(., "offspring_production")` side-channel that the naive `$parameters` mapping would drop), and surfaced a NEWS gap (`p$node_schedule_ode_times -> p$ode_times`) now folded into the #413 entry. Migrated expressions verified against the installed post-migration plant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)