### PR TITLE
Resolve #478 solver-core open questions (competition-error scaling, new_node recompute)

### DIFF
--- a/inst/include/plant/scm.h
+++ b/inst/include/plant/scm.h
@@ -435,9 +435,13 @@ std::vector<std::vector<double>> SCM<T, E>::refinement_error_by_node() const {
 template <typename T, typename E>
 std::vector<double>
 SCM<T, E>::r_compute_competition_effect_error_by_node_for_species_i(util::index species_index) const {
-  // TODO(#478): I think we need to scale this by total area; that should be
-  // computed for everything so will get passed in as an argument.
-  // const double tot_competition_effect  = patch.compute_competition(0.0);
+  // The per-node error is scaled by the total competition effect inside the
+  // patch-level call below: it computes compute_competition(0.0) -- which
+  // already divides by patch area -- and passes it through as the scaling
+  // argument. The live schedule-refinement collector
+  // (Patch::collect_competition_errors) reconstructs the signal via this same
+  // path, so no extra area scaling is needed here to keep them consistent
+  // (resolves the scaling question in #478).
   const size_t idx = species_index.check_bounds(patch.size());
   return patch.r_compute_competition_effect_error_by_node_for_species_i(idx);
 }

--- a/inst/include/plant/species.h
+++ b/inst/include/plant/species.h
@@ -149,8 +149,14 @@ void Species<T,E>::clear() {
 
 template <typename T, typename E>
 void Species<T,E>::introduce_new_node() {
+  // new_node already holds the initial conditions computed against the current
+  // environment by the most recent compute_rates() call (see compute_rates ->
+  // new_node.compute_initial_conditions above), and the member is refreshed
+  // again on the next compute_rates() ready for the following introduction.
+  // Recomputing it here would be redundant, and would (wrongly) re-seed against
+  // the post-introduction environment rather than the environment at the
+  // node's introduction time (resolves the recompute question in #478).
   nodes.push_back(new_node);
-  // TODO(#478): Should the new_node be recomputed here?
 }
 
 // If a species contains no individuals, we return the height of a


### PR DESCRIPTION
Addresses the solver-core open questions from #478. Two of the items flagged as
correctness-critical turned out to already be handled by the surrounding code, so
this replaces the speculative `TODO`s with explanatory comments rather than changing
behaviour. A third (efficiency) item was measured and is **not** worth doing as
proposed. See the [#478 status comment](https://github.com/traitecoevo/plant/issues/478#issuecomment-4773238507) for the full write-up.

## Item 1 — `scm.h` competition-effect error scaling → already done
The SCM probe delegates to `Patch::r_compute_competition_effect_error_by_node_for_species_i`,
which computes `compute_competition(0.0)` — already divided by patch `area` — and passes
it through as the scaling argument. The live schedule-refinement collector
(`collect_competition_errors`) uses the same path, so the hand-reconstructed diagnostic is
already consistent with it. Removed the stale `TODO` + dead commented code.

## Item 2 — `species.h::introduce_new_node`, recompute `new_node`? → no
`new_node` is recomputed against the current environment every step via
`compute_rates → new_node.compute_initial_conditions(...)` and refreshed again before the
next introduction, so the pushed copy already carries valid initial conditions. Recomputing
here would be redundant and would re-seed against the post-introduction environment.
Documented instead of recomputing.

## Item 3 — `patch.h` introduction-time rescale → measured, not done
Profiled FF16 `run_scm`: the full-rebuild on introduction is ~5.4% of `SCM::run()` (less on
TF24). A blind `construct`→`rescale` swap would not be bit-identical and would risk
under-resolving the newly introduced node's competition kink. Left as-is; the real lever
(partial below-seedling reconstruction) belongs in odelia. Not changed in this PR.

## Notes
- Comment-only changes to core headers; `make compile` clean, no behaviour change, no NEWS
  entry needed (not R-facing).
- The two minor audit items (`species.h:60` structural, `patch.h` env-vector utility) are
  left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)