### PR TITLE
ci: auto-add new issues to traitecoevo project 5

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,14 @@
+name: Add issues to project
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/traitecoevo/projects/5
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adds a GitHub Actions workflow that adds every newly opened issue to the org project board ([traitecoevo/projects/5](https://github.com/orgs/traitecoevo/projects/5)).

Mirrors the setup in the Falster Lab manuscript-mayhem repo (minus the paper/sub-issue logic specific to that repo).

## Notes
- Requires the `ADD_TO_PROJECT_PAT` repo secret (set, with org Projects write + repo Issues read scope).
- Triggers on `issues: opened`. Because GitHub runs the `issues` event against the workflow file on the **default branch**, this only takes effect once merged to `develop`.
- Only catches issues opened after merge; existing issues are not backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)