### PR TITLE
ci: only auto-label 'task' when issue opened with no label

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -14,7 +14,8 @@ jobs:
           project-url: https://github.com/orgs/traitecoevo/projects/5
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
-      - name: Label issue as task
+      - name: Label issue as task (only if opened with no label)
+        if: ${{ github.event.issue.labels[0] == null }}
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Tweaks the add-to-project workflow so the `task` label is only applied when an issue is opened **without any label**. If the author picks an appropriate label, it's kept and `task` is not forced on.

Implemented with a step-level guard: `if: github.event.issue.labels[0] == null`.

(The VSCode GitHub Actions extension flags `labels[0]` with a false-positive "Context access might be invalid" warning; the expression is valid Actions syntax.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)