### PR TITLE
[TF24 hydraulics] Fix arm64 hydraulic_cost_Sperry test failure (FMA contraction)

### DIFF
--- a/src/leaf_model.cpp
+++ b/src/leaf_model.cpp
@@ -1067,6 +1067,13 @@ void Leaf::set_leaf_states_rates_from_psi_stem(double psi_stem, double psi_upstr
 // Sperry et al. 2017; Sabot et al. 2020 implementation
 
 double Leaf::hydraulic_cost_Sperry(double psi_stem, double psi_upstream) {
+  // Cost is definitionally zero when the potentials are equal. Returning it
+  // explicitly avoids a tiny non-zero residual from FMA contraction of the
+  // k_l_soil_ - k_l_stem_ subtraction (arch-dependent; see arm64 build, #468).
+  if (psi_stem == psi_upstream) {
+    hydraulic_cost_ = 0.0;
+    return hydraulic_cost_;
+  }
   double k_l_soil_ = leaf_specific_conductance_max_ * proportion_of_conductivity(psi_upstream);
   double k_l_stem_ = leaf_specific_conductance_max_ * proportion_of_conductivity(psi_stem);
   

--- a/tests/testthat/test-leaf.r
+++ b/tests/testthat/test-leaf.r
@@ -243,7 +243,7 @@ expect_error(l$set_physiology(area_leaf = area_leaf_, mass_root_prop = mass_root
   expect_equal(l$transpiration_, 0)
   
   #costs 0 when psi_stem == psi_soil == 0
-  expect_equal(l$hydraulic_cost_Sperry(psi_stem = psi_soil, psi_upstream = psi_soil) == 0, TRUE)
+  expect_equal(l$hydraulic_cost_Sperry(psi_stem = psi_soil, psi_upstream = psi_soil), 0)
   #costs positive even when transpiration stream is 0 in hydraulic cost tf
   expect_equal(l$hydraulic_cost_TF(psi_soil) > 0, TRUE)
   
@@ -279,7 +279,7 @@ expect_error(l$set_physiology(area_leaf = area_leaf_, mass_root_prop = mass_root
   
   
   #calculate the hydraulic cost usign the sperry method, should be 0 when psi_soil is equivalent to psi_stem
-  expect_equal(l$hydraulic_cost_Sperry(psi_soil, psi_soil) == 0, TRUE)
+  expect_equal(l$hydraulic_cost_Sperry(psi_soil, psi_soil), 0)
   #calculate hydraulic cost using TF method, should be greater than 0 when psi_soil is greater than 0
   expect_equal(l$hydraulic_cost_TF(psi_soil) > 0, TRUE)
   
@@ -295,8 +295,8 @@ expect_error(l$set_physiology(area_leaf = area_leaf_, mass_root_prop = mass_root
   l$set_physiology(area_leaf = area_leaf_, mass_root_prop = 1, rho = 608, a_bio = 0.0245, PPFD = PPFD, psi_soil = psi_soil, soil_depth = soil_depth, leaf_specific_conductance_max = leaf_specific_conductance_max, atm_vpd = atm_vpd, ca = ca, sapwood_volume_per_leaf_area = sapwood_volume_per_leaf_area, leaf_temp = leaf_temp_, atm_o2_kpa = atm_o2_kpa_, atm_kpa = atm_kpa_)
    
   l$set_leaf_states_rates_from_psi_stem(0, 0)
-  expect_equal(l$hydraulic_cost_TF(psi_soil) == 0, TRUE)
-  expect_equal(l$hydraulic_cost_Sperry(psi_soil, psi_soil) == 0, TRUE)
+  expect_equal(l$hydraulic_cost_TF(psi_soil), 0)
+  expect_equal(l$hydraulic_cost_Sperry(psi_soil, psi_soil), 0)
   
   #psi_soil == psi_stem means A == -R_d_
   expect_equal(l$assim_colimited_, -l$R_d_)


### PR DESCRIPTION
## Problem

The r-universe build failed on **Linux arm64** (R-devel and R-release) with two failures in `test-leaf.r` (lines 246, 282), while all other 2282 tests passed. See [run 28071487682](https://github.com/r-universe/traitecoevo/actions/runs/28071487682).

## Root cause

`hydraulic_cost_Sperry` computes `k_l_soil_ - k_l_stem_`, which is definitionally zero when `psi_stem == psi_upstream` (both terms are `lscm * proportion_of_conductivity(psi)` with the same `psi`). On arm64 GCC (`-ffp-contract=fast`) the subtraction was fused into an FMA, mixing the full-precision product with the already-rounded `k_l_stem_` and leaving a ~1e-16 residual instead of exactly `0`. The test's exact `== 0` assertion then failed.

The `psi = 0` case passed because `exp(-0) = 1` exactly, so no rounding residual exists there — which is why the failure was value- and arch-specific.

## Fix

- **`src/leaf_model.cpp`**: return exact `0.0` when `psi_stem == psi_upstream` (the definitional value). The added branch is reliably not-taken in the optimizer hot path, so no measurable performance impact.
- **`tests/testthat/test-leaf.r`**: replace the fragile `... == 0, TRUE` assertions with tolerance-based `expect_equal(..., 0)`.

Either change alone resolves the failure; together they remove the arch-dependent residual at the source and stop the tests relying on exact floating-point equality.

## Testing

`make compile` + `testthat::test_file("tests/testthat/test-leaf.r")` → `[ FAIL 0 | PASS 201 ]` locally (Apple clang; arm-GCC contraction not reproducible locally, but fix forces exact zero on every toolchain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)