### PR TITLE
[speed] [TF24 hydraulics] Share prepare_collar_solve in TF24f FD solve + two-sided E-conservation test (#530, #533)

### DIFF
--- a/inst/include/plant/leaf_model.h
+++ b/inst/include/plant/leaf_model.h
@@ -315,6 +315,15 @@ public:
   // exactly the same outputs as find_root_collar_psi and returns profit_. Used by
   // TF24f's gradient-ascent acclimation (#525).
   double evaluate_root_collar_psi(double target_opt_root_psi);
+  // Evaluate profit at a given root-collar potential (positive magnitude)
+  // *assuming prepare_collar_solve has already run this step* (soil-side caches
+  // built, feasible interval [bound_a, bound_b] known). Clamps the target into
+  // the interval and sets the operating point (opt_psi_stem_, root_collar_psi_,
+  // profit_), returning profit_. This is the post-prepare body of
+  // evaluate_root_collar_psi, factored out so the centred finite-difference leaf
+  // solve can share one prepare_collar_solve across its three profit evals (#530).
+  double profit_at_collar_psi(double target_opt_root_psi,
+                              double bound_a, double bound_b);
   // Exact d(profit)/d(opt_root_psi) at a given root-collar potential (positive
   // magnitude), for TF24f's acclimation tracking (#525/#527). Combines
   // forward-mode AD for the analytic photosynthesis/cost algebra, the

--- a/src/leaf_model.cpp
+++ b/src/leaf_model.cpp
@@ -848,6 +848,18 @@ double Leaf::evaluate_root_collar_psi(double target_opt_root_psi){
       return profit_;
     }
 
+    return profit_at_collar_psi(target_opt_root_psi, bound_a, bound_b);
+}
+
+// Post-prepare body of evaluate_root_collar_psi (see header). Kept as a separate
+// entry point so callers that evaluate several collar potentials within one step
+// (the centred finite difference, #530) can run prepare_collar_solve once and
+// reuse the soil-side caches across every profit eval. The clamp into
+// [bound_a, bound_b] is identical to evaluate_root_collar_psi's, so near a
+// boundary a perturbed potential collapses onto the boundary -- which is exactly
+// how the FD path degrades gracefully to a one-sided difference.
+double Leaf::profit_at_collar_psi(double target_opt_root_psi,
+                                  double bound_a, double bound_b){
     const double opt_root_psi =
         std::min(std::max(target_opt_root_psi, bound_a), bound_b);
 

--- a/src/tf24f_strategy.cpp
+++ b/src/tf24f_strategy.cpp
@@ -54,33 +54,50 @@ void TF24f_Strategy::solve_leaf() {
     leaf.find_root_collar_psi();
     return;
   }
-  // Establish the operating point (and the clamped collar psi `used`) and leave
-  // the leaf outputs there for compute_rates' aux reads.
-  leaf.evaluate_root_collar_psi(tracked_root_psi_);
-  const double used = -leaf.root_collar_psi_;
-
   if (use_ad_gradient) {
     // Exact gradient (default, #527): forward-mode AD over the analytic algebra
     // + IFT at the ci root-find + analytic spline derivatives for the transport.
     // No O(h) bias and no finite-difference step to tune.
+    // Establish the operating point (and the clamped collar psi `used`) and leave
+    // the leaf outputs there for compute_rates' aux reads.
+    leaf.evaluate_root_collar_psi(tracked_root_psi_);
+    const double used = -leaf.root_collar_psi_;
     dprofit_dpsi_ = leaf.dprofit_droot_collar_psi(used);
     leaf.evaluate_root_collar_psi(used);  // restore operating-point outputs
   } else {
     // Centred finite-difference fallback (#526), perturbing about the clamped
     // operating value `used`. A one-sided difference biases the fixed point to
     // psi* - h/2 (O(h)); the centred form cancels that term (O(h^2)) for one
-    // extra leaf evaluation. Near a boundary the clamp inside
-    // evaluate_root_collar_psi collapses one arm, degrading it gracefully to a
-    // one-sided difference that still points back into the interior.
+    // extra leaf evaluation. Near a boundary the clamp collapses one arm,
+    // degrading it gracefully to a one-sided difference that still points back
+    // into the interior.
     const double h = psi_fd_step;
     if (!util::is_finite(h) || h <= 0.0) {
       util::stop("TF24f: psi_fd_step must be finite and > 0 (got " +
                  util::to_string(h) + ")");
     }
-    const double p_plus  = leaf.evaluate_root_collar_psi(used + h);
-    const double p_minus = leaf.evaluate_root_collar_psi(used - h);
+    // Share one prepare_collar_solve across the three profit evals (#530): the
+    // plant/environment state is fixed within this solve, so the soil-side caches
+    // and feasible interval are identical at `used` and `used ± h`. Re-deriving
+    // them per eval (the old four-evaluate_root_collar_psi form) was the ~29%
+    // cost over the forward difference.
+    double bound_a, bound_b;
+    if (!leaf.prepare_collar_solve(bound_a, bound_b)) {
+      // Operating point fully determined by feasibility handling (shutdown /
+      // assim<0 / collapsed interval); no interior interval to perturb in, so the
+      // gradient is zero (matching the old form, where every clamped eval
+      // returned the same fixed profit_). Leaf outputs are already at the
+      // operating point.
+      dprofit_dpsi_ = 0.0;
+      return;
+    }
+    // `used` is the tracked state clamped into the feasible interval -- the same
+    // value the old leading evaluate_root_collar_psi(tracked_root_psi_) produced.
+    const double used = std::min(std::max(tracked_root_psi_, bound_a), bound_b);
+    const double p_plus  = leaf.profit_at_collar_psi(used + h, bound_a, bound_b);
+    const double p_minus = leaf.profit_at_collar_psi(used - h, bound_a, bound_b);
     dprofit_dpsi_ = (p_plus - p_minus) / (2.0 * h);
-    leaf.evaluate_root_collar_psi(used);
+    leaf.profit_at_collar_psi(used, bound_a, bound_b);  // restore operating point
   }
 }
 

--- a/tests/testthat/test-strategy-tf24f.R
+++ b/tests/testthat/test-strategy-tf24f.R
@@ -312,14 +312,21 @@ test_that("acclimation runs, is active, and converges to TF24", {
 # time-varying rainfall driver.
 #
 # Reduced to 5 soil depths (from 15) purely for speed -- ~5x faster with no
-# material change to the closure. The check is deliberately one-sided
-# (1 - ratio < tol, i.e. ratio > 1 - tol): over so short a transient patch the
-# cumulative-flux closure does not settle to a tight two-sided tolerance, but
-# the stem side must not fall materially *below* the root side.
+# material change to the closure.
+#
+# Two-sided check (#533): the original assertion was one-sided (1 - ratio < tol),
+# which could only catch the stem side falling *below* the root side, not an
+# overshoot. The overshoot it would otherwise have masked is a short-patch
+# transient, not a conservation gap: the end-of-patch closure converges to 1.0 as
+# the patch lengthens (ratio ~1.25 at lifetime 2 -> ~1.01 at lifetime 10 -> ~1.00
+# at lifetime 40), because the size distribution and the tracked leaf states are
+# still equilibrating early in a short patch. We therefore run a longer patch
+# (lifetime 10, ~2.4s) where instantaneous flux balance has settled and assert a
+# genuine two-sided closure |1 - ratio| < tol.
 
 test_that("E conservation", {
 
-  max_patch_lifetime <- 2
+  max_patch_lifetime <- 10
   p0 <- scm_base_parameters("TF24f", "TF24_Env")
   p0$max_patch_lifetime <- max_patch_lifetime
   traits <- trait_matrix(c(0.07), c("lma"))
@@ -347,7 +354,8 @@ test_that("E conservation", {
       root_side = (sum_resource_depletion - dplyr::lag(sum_resource_depletion)) /
                   (time - dplyr::lag(time))) -> root_side
 
-  expect_true(1 - (stem_side / root_side$root_side[-1])[length(stem_side)] < 5e-2)
+  closure <- (stem_side / root_side$root_side[-1])[length(stem_side)]
+  expect_equal(closure, 1, tolerance = 5e-2)
 })
 
 test_that("TF24f AD gradient tracks TF24 (#527)", {


### PR DESCRIPTION
Fixes #530 and #533.

## #530 — Share `prepare_collar_solve` across the centred-difference leaf evals

The centred finite-difference leaf solve ran **four** `evaluate_root_collar_psi` calls per rate evaluation, each independently re-running `prepare_collar_solve` (soil-side caches + the two `find_root_psi` root-finds) — even though the plant/environment state is fixed within a single solve.

- Factored the post-prepare body of `evaluate_root_collar_psi` into a new `Leaf::profit_at_collar_psi(target, bound_a, bound_b)`. `evaluate_root_collar_psi` now calls `prepare_collar_solve` then this helper, so its existing single-eval semantics (birth-init / AD paths) are unchanged and bit-identical.
- Rewrote the FD branch of `TF24f_Strategy::solve_leaf` to call `prepare_collar_solve` **once**, then evaluate profit at `used` and `used ± h` directly, reusing the soil-side caches. The boundary clamp is unchanged, so graceful degradation to a one-sided difference near the `[bound_a, bound_b]` edges is preserved and the gradient is numerically identical.

**Same-session A/B (lifetime=20 patch, FD path): 2.93s → 1.58s (~46% faster)**, exceeding the issue's ~22% target — the shared setup removes the dominant root-finds, not just one of four evals. The FD path still tracks TF24 to 100% of heights within 1% (median |Δh| ≈ 9e-5).

## #533 — Two-sided E-conservation test

The `E conservation` assertion was one-sided (`1 - ratio < tol`), which could only catch the stem side falling *below* the root side, never an overshoot.

Investigation (sweeping `max_patch_lifetime`, 5 soil depths) shows the ~25% overshoot is a **short-patch transient, not a conservation gap** — end-of-patch closure converges to 1.0 as the patch lengthens:

| lifetime | end-of-patch closure |
|---|---|
| 2 | 1.25 |
| 5 | 0.99 |
| 10 | 1.01 |
| 20 | 1.01 |
| 40 | 1.00 |

The transient reflects the size distribution and tracked leaf states still equilibrating early in a short patch. The test now runs a longer patch (lifetime 10, ~2.4s), where instantaneous flux balance has settled, and asserts a genuine two-sided closure: `expect_equal(closure, 1, tolerance = 5e-2)`.

## Tests

All green: `test-leaf.r` (208), `test-strategy-tf24.R` (52), `test-strategy-tf24f.R` (60), `test-environment-TF24.R` (70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)