### PR TITLE
[AutoDiff] Scalar-templated FF16 net-production kernel + resident-light AD composition (#472 scope B, Milestone A + B-core)

### DIFF
--- a/inst/include/plant/models/ff16_production_kernel.h
+++ b/inst/include/plant/models/ff16_production_kernel.h
@@ -2,6 +2,9 @@
 #ifndef PLANT_PLANT_FF16_PRODUCTION_KERNEL_H_
 #define PLANT_PLANT_FF16_PRODUCTION_KERNEL_H_
 
+#include <vector>
+#include <cstddef>
+
 // Scalar-templated core of the FF16 single-plant net-mass-production chain
 // (#472 scope B / traitecoevo/plant#537, Milestone A). The pieces below [eqn
 // 12-15] are elementary arithmetic, so templating them on the scalar S makes net
@@ -73,6 +76,29 @@ S ff16_net_mass_production_crown_top(const FF16ProdPars<S>& p,
   const S turnover     = ff16_turnover(mass_leaf, mass_bark, mass_sapwood, mass_root,
                                        p.k_l, p.k_b, p.k_s, p.k_r);
   return ff16_net_production_A(p.a_bio, p.a_y, assimilation, respiration, turnover);
+}
+
+// Deep-crown assimilation as a FROZEN-REPLAY weighted sum (#472 scope B,
+// Milestone B). The production model's default assimilation integrates
+// assimilation_leaf(light(z)) * q(z/height, z) over crown depth with adaptive
+// Gauss-Kronrod. Per the two-pass plan we do NOT differentiate the adaptive
+// controller: pass 1 (double) discovers the nodes z_j and the COMBINED weights
+// wq_j = w_j * q(z_j/height, z_j) (the leaf-area density q is constant in the
+// physiology traits, so it folds into the frozen weight); pass 2 replays
+//   A = area_leaf * sum_j wq_j * assimilation_leaf(a_p1, a_p2, light(z_j)).
+// `light` is any callable z -> S (e.g. an AD-capable resident light spline,
+// odelia::interpolator::basic_interpolator<S>), so A is differentiable w.r.t.
+// a_p1/a_p2 and w.r.t. light's knot values (the resident self-shading coupling).
+template <typename S, typename LightFn>
+S ff16_assimilation_deep_crown_replay(S a_p1, S a_p2, S area_leaf,
+                                      const std::vector<double>& z,
+                                      const std::vector<double>& wq,
+                                      LightFn&& light) {
+  S A = S(0.0);
+  for (std::size_t j = 0; j < z.size(); ++j) {
+    A += wq[j] * ff16_assimilation_leaf(a_p1, a_p2, S(light(z[j])));
+  }
+  return area_leaf * A;
 }
 
 }  // namespace plant

--- a/inst/include/plant/models/ff16_production_kernel.h
+++ b/inst/include/plant/models/ff16_production_kernel.h
@@ -1,0 +1,80 @@
+// -*-c++-*-
+#ifndef PLANT_PLANT_FF16_PRODUCTION_KERNEL_H_
+#define PLANT_PLANT_FF16_PRODUCTION_KERNEL_H_
+
+// Scalar-templated core of the FF16 single-plant net-mass-production chain
+// (#472 scope B / traitecoevo/plant#537, Milestone A). The pieces below [eqn
+// 12-15] are elementary arithmetic, so templating them on the scalar S makes net
+// production differentiable w.r.t. traits by reverse-mode AD with no special
+// handling. They are the SINGLE SOURCE OF TRUTH: FF16_Strategy's double methods
+// delegate to them (so the existing FF16 test suite validates faithfulness), and
+// the AD calibration path instantiates them with an active scalar.
+
+namespace plant {
+
+// [eqn 12] Photosynthetic rate per leaf area; x is openness in [0,1].
+template <typename S>
+S ff16_assimilation_leaf(S a_p1, S a_p2, S x) {
+  return a_p1 * x / (x + a_p2);
+}
+
+// [eqn 13] Total maintenance respiration (linear in the mass cascade).
+template <typename S>
+S ff16_respiration(S mass_leaf, S mass_sapwood, S mass_bark, S mass_root,
+                   S r_l, S r_s, S r_b, S r_r) {
+  return r_l * mass_leaf + r_b * mass_bark + r_s * mass_sapwood + r_r * mass_root;
+}
+
+// [eqn 14] Total turnover.
+template <typename S>
+S ff16_turnover(S mass_leaf, S mass_bark, S mass_sapwood, S mass_root,
+                S k_l, S k_b, S k_s, S k_r) {
+  return k_l * mass_leaf + k_b * mass_bark + k_s * mass_sapwood + k_r * mass_root;
+}
+
+// [eqn 15] Net production from assimilation/respiration/turnover.
+template <typename S>
+S ff16_net_production_A(S a_bio, S a_y, S assimilation, S respiration, S turnover) {
+  return a_bio * a_y * (assimilation - respiration) - turnover;
+}
+
+// The FF16 parameters the crown-top net-production chain reads, plus the
+// prepare_strategy()-derived eta_c. Used by the all-in-one convenience below
+// (the AD calibration entry point); the hot double path uses the per-piece
+// functions directly with pars.* members.
+template <typename S>
+struct FF16ProdPars {
+  S lma, rho, theta, a_b1, a_r1, eta_c;
+  S a_p1, a_p2;
+  S r_l, r_s, r_b, r_r;
+  S k_l, k_b, k_s, k_r;
+  S a_bio, a_y;
+};
+
+// Whole single-plant net production under the CROWN-TOP assimilation variant (a
+// single light evaluation light_E at the canopy top; no quadrature -- the
+// adaptive crown integral is a separate frozen-replay concern, Milestone B).
+// Mirrors FF16_Strategy's mass cascade + assimilation_crown_top + the pieces
+// above exactly. light_E is the (fixed, double on the resident path) light
+// fraction at the crown.
+template <typename S>
+S ff16_net_mass_production_crown_top(const FF16ProdPars<S>& p,
+                                     S height, S area_leaf, S light_E) {
+  const S mass_leaf    = area_leaf * p.lma;
+  const S area_sapwood = area_leaf * p.theta;
+  const S mass_sapwood = area_sapwood * height * p.eta_c * p.rho;
+  const S area_bark    = p.a_b1 * area_leaf * p.theta;
+  const S mass_bark    = area_bark * height * p.eta_c * p.rho;
+  const S mass_root    = p.a_r1 * area_leaf;
+
+  const S assimilation = area_leaf * ff16_assimilation_leaf(p.a_p1, p.a_p2, light_E);
+  const S respiration  = ff16_respiration(mass_leaf, mass_sapwood, mass_bark, mass_root,
+                                          p.r_l, p.r_s, p.r_b, p.r_r);
+  const S turnover     = ff16_turnover(mass_leaf, mass_bark, mass_sapwood, mass_root,
+                                       p.k_l, p.k_b, p.k_s, p.k_r);
+  return ff16_net_production_A(p.a_bio, p.a_y, assimilation, respiration, turnover);
+}
+
+}  // namespace plant
+
+#endif

--- a/inst/include/plant/models/ff16_production_kernel.h
+++ b/inst/include/plant/models/ff16_production_kernel.h
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <cstddef>
+#include <cmath>   // std::pow; XAD provides pow for active types via ADL
 
 // Scalar-templated core of the FF16 single-plant net-mass-production chain
 // (#472 scope B / traitecoevo/plant#537, Milestone A). The pieces below [eqn
@@ -14,6 +15,15 @@
 // the AD calibration path instantiates them with an active scalar.
 
 namespace plant {
+
+// [eqn 2] Leaf area as a function of height (inverse of [eqn 3]). Carries the
+// allometric traits a_l1, a_l2, so it is the entry point through which a trait
+// reaches both the mass cascade and the resident competition / light spline.
+template <typename S>
+S ff16_area_leaf(S a_l1, S a_l2, S height) {
+  using std::pow;
+  return pow(height / a_l1, 1.0 / a_l2);
+}
 
 // [eqn 12] Photosynthetic rate per leaf area; x is openness in [0,1].
 template <typename S>
@@ -60,9 +70,12 @@ struct FF16ProdPars {
 // Mirrors FF16_Strategy's mass cascade + assimilation_crown_top + the pieces
 // above exactly. light_E is the (fixed, double on the resident path) light
 // fraction at the crown.
+// Mass cascade -> respiration/turnover -> net production, GIVEN the assimilation
+// rate. Shared by every assimilation variant (crown-top, deep-crown, ...), so
+// the variants differ only in how they compute `assimilation`.
 template <typename S>
-S ff16_net_mass_production_crown_top(const FF16ProdPars<S>& p,
-                                     S height, S area_leaf, S light_E) {
+S ff16_net_from_components(const FF16ProdPars<S>& p, S height, S area_leaf,
+                           S assimilation) {
   const S mass_leaf    = area_leaf * p.lma;
   const S area_sapwood = area_leaf * p.theta;
   const S mass_sapwood = area_sapwood * height * p.eta_c * p.rho;
@@ -70,12 +83,18 @@ S ff16_net_mass_production_crown_top(const FF16ProdPars<S>& p,
   const S mass_bark    = area_bark * height * p.eta_c * p.rho;
   const S mass_root    = p.a_r1 * area_leaf;
 
-  const S assimilation = area_leaf * ff16_assimilation_leaf(p.a_p1, p.a_p2, light_E);
-  const S respiration  = ff16_respiration(mass_leaf, mass_sapwood, mass_bark, mass_root,
-                                          p.r_l, p.r_s, p.r_b, p.r_r);
-  const S turnover     = ff16_turnover(mass_leaf, mass_bark, mass_sapwood, mass_root,
-                                       p.k_l, p.k_b, p.k_s, p.k_r);
+  const S respiration = ff16_respiration(mass_leaf, mass_sapwood, mass_bark, mass_root,
+                                         p.r_l, p.r_s, p.r_b, p.r_r);
+  const S turnover    = ff16_turnover(mass_leaf, mass_bark, mass_sapwood, mass_root,
+                                      p.k_l, p.k_b, p.k_s, p.k_r);
   return ff16_net_production_A(p.a_bio, p.a_y, assimilation, respiration, turnover);
+}
+
+template <typename S>
+S ff16_net_mass_production_crown_top(const FF16ProdPars<S>& p,
+                                     S height, S area_leaf, S light_E) {
+  const S assimilation = area_leaf * ff16_assimilation_leaf(p.a_p1, p.a_p2, light_E);
+  return ff16_net_from_components(p, height, area_leaf, assimilation);
 }
 
 // Deep-crown assimilation as a FROZEN-REPLAY weighted sum (#472 scope B,

--- a/inst/include/plant/models/ff16_strategy.h
+++ b/inst/include/plant/models/ff16_strategy.h
@@ -6,6 +6,7 @@
 #include <plant/models/ff16_environment.h>
 #include <plant/qag.h>
 #include <plant/canopy_shape.h>
+#include <plant/models/ff16_production_kernel.h>
 
 namespace plant {
 
@@ -161,7 +162,10 @@ public:
   // Inline (header) so it can inline into the hot competition/assimilation
   // paths that reach it from templated Individual<FF16> code (no LTO build).
   double area_leaf(double height) const {
-    return std::pow(height / pars.a_l1, 1.0 / pars.a_l2);
+    // Single source: scalar-templated kernel (#472 scope B). Bit-identical to
+    // the previous std::pow(height/a_l1, 1/a_l2); validated by the FF16
+    // reference-comparison test.
+    return ff16_area_leaf(pars.a_l1, pars.a_l2, height);
   }
 
   // [eqn 1] mass_leaf (inverse of [eqn 2])

--- a/src/ff16_strategy.cpp
+++ b/src/ff16_strategy.cpp
@@ -1,4 +1,5 @@
 #include <plant/models/ff16_strategy.h>
+#include <plant/models/ff16_production_kernel.h>
 
 namespace plant {
 
@@ -202,17 +203,17 @@ double FF16_Strategy::assimilation_crown_top(const FF16_Environment& environment
 // Photosynthetic rate per leaf area
 // `x` is openness, ranging from 0 to 1.
 double FF16_Strategy::assimilation_leaf(double x) const {
-  return pars.a_p1 * x / (x + pars.a_p2);
+  // Single source: scalar-templated kernel (#472 scope B, Milestone A).
+  return ff16_assimilation_leaf(pars.a_p1, pars.a_p2, x);
 }
 
 // [eqn 13] Total maintenance respiration
 // NOTE: In contrast with Falster ref model, we do not normalise by pars.a_y*pars.a_bio.
 double FF16_Strategy::respiration(double mass_leaf, double mass_sapwood,
                              double mass_bark, double mass_root) const {
-  return respiration_leaf(mass_leaf) +
-         respiration_bark(mass_bark) +
-         respiration_sapwood(mass_sapwood) +
-         respiration_root(mass_root);
+  // Single source: scalar-templated kernel (#472 scope B, Milestone A).
+  return ff16_respiration(mass_leaf, mass_sapwood, mass_bark, mass_root,
+                          pars.r_l, pars.r_s, pars.r_b, pars.r_r);
 }
 
 double FF16_Strategy::respiration_leaf(double mass) const {
@@ -234,10 +235,9 @@ double FF16_Strategy::respiration_root(double mass) const {
 // [eqn 14] Total turnover
 double FF16_Strategy::turnover(double mass_leaf, double mass_bark,
                           double mass_sapwood, double mass_root) const {
-   return turnover_leaf(mass_leaf) +
-          turnover_bark(mass_bark) +
-          turnover_sapwood(mass_sapwood) +
-          turnover_root(mass_root);
+   // Single source: scalar-templated kernel (#472 scope B, Milestone A).
+   return ff16_turnover(mass_leaf, mass_bark, mass_sapwood, mass_root,
+                        pars.k_l, pars.k_b, pars.k_s, pars.k_r);
 }
 
 double FF16_Strategy::turnover_leaf(double mass) const {
@@ -262,7 +262,8 @@ double FF16_Strategy::turnover_root(double mass) const {
 // before the minus sign is SCM's N, our `net_mass_production_dt` is SCM's P.
 double FF16_Strategy::net_mass_production_dt_A(double assimilation, double respiration,
                                 double turnover) const {
-  return pars.a_bio * pars.a_y * (assimilation - respiration) - turnover;
+  // Single source: scalar-templated kernel (#472 scope B, Milestone A).
+  return ff16_net_production_A(pars.a_bio, pars.a_y, assimilation, respiration, turnover);
 }
 
 // One shot calculation of net_mass_production_dt

--- a/tests/testthat/test-ff16-ad-kernel.R
+++ b/tests/testthat/test-ff16-ad-kernel.R
@@ -17,12 +17,16 @@ is_pkgload_dll_plant <- function() {
 }
 
 compile_ff16_ad_kernel <- function() {
-  plant_inc <- system.file("include", package = "plant")
-  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  # Prefer the source tree (has the header in dev/load_all) then the installed
+  # package (CI on the built branch); skip if neither carries the kernel header.
+  cand <- c(tryCatch(here::here("inst/include"), error = function(e) ""),
+            system.file("include", package = "plant"))
+  has_hdr <- file.exists(file.path(cand, "plant/models/ff16_production_kernel.h"))
+  testthat::skip_if(!any(has_hdr),
+                    "FF16 AD kernel header not found on include path.")
+  plant_inc <- cand[has_hdr][1]
   odelia_inc <- system.file("include", package = "odelia")
   odelia_so <- system.file("libs", "odelia.so", package = "odelia")
-  testthat::skip_if(!file.exists(file.path(plant_inc, "plant/models/ff16_production_kernel.h")),
-                    "FF16 AD kernel header not found on include path.")
   testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),
                     "odelia shared library not found for tape linking.")
   withr::local_envvar(

--- a/tests/testthat/test-ff16-ad-kernel.R
+++ b/tests/testthat/test-ff16-ad-kernel.R
@@ -1,0 +1,107 @@
+# Milestone A (#472 scope B / #537): reverse-mode AD gradient of FF16 single-plant
+# net mass production (crown-top variant) w.r.t. traits, through the templated
+# kernel (plant/models/ff16_production_kernel.h) that FF16_Strategy's double
+# methods delegate to. Faithfulness of that kernel to the live FF16 numerics is
+# covered by the existing FF16 suite (the reference-comparison test passes
+# because the double methods now route through the kernel); here we check that
+# the AD gradient is correct (vs finite differences).
+#
+# The XAD adjoint Tape<T,N> is instantiated in odelia's shared library, so this
+# sourceCpp build links against it via PKG_LIBS (the odelia AD-test recipe).
+
+is_pkgload_dll_plant <- function() {
+  loaded <- getLoadedDLLs()
+  if (!("plant" %in% names(loaded))) return(FALSE)
+  p <- tryCatch(loaded[["plant"]][["path"]], error = function(e) "")
+  is.character(p) && length(p) == 1 && grepl("pkgload", p, fixed = TRUE)
+}
+
+compile_ff16_ad_kernel <- function() {
+  plant_inc <- system.file("include", package = "plant")
+  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  odelia_inc <- system.file("include", package = "odelia")
+  odelia_so <- system.file("libs", "odelia.so", package = "odelia")
+  testthat::skip_if(!file.exists(file.path(plant_inc, "plant/models/ff16_production_kernel.h")),
+                    "FF16 AD kernel header not found on include path.")
+  testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),
+                    "odelia shared library not found for tape linking.")
+  withr::local_envvar(
+    PKG_CPPFLAGS = paste(paste0("-I", shQuote(plant_inc)),
+                         paste0("-I", shQuote(odelia_inc))),
+    PKG_LIBS = shQuote(normalizePath(odelia_so)))
+
+  res <- tryCatch({
+    Rcpp::sourceCpp(code = '
+      #include <Rcpp.h>
+      #include <vector>
+      #include <XAD/XAD.hpp>
+      #include <plant/models/ff16_production_kernel.h>
+
+      static plant::FF16ProdPars<xad::adj<double>::active_type>
+      pod_ad(const std::vector<xad::adj<double>::active_type>& v) {
+        plant::FF16ProdPars<xad::adj<double>::active_type> p;
+        p.lma=v[0];p.rho=v[1];p.theta=v[2];p.a_b1=v[3];p.a_r1=v[4];p.eta_c=v[5];
+        p.a_p1=v[6];p.a_p2=v[7];p.r_l=v[8];p.r_s=v[9];p.r_b=v[10];p.r_r=v[11];
+        p.k_l=v[12];p.k_b=v[13];p.k_s=v[14];p.k_r=v[15];p.a_bio=v[16];p.a_y=v[17];
+        return p;
+      }
+      static plant::FF16ProdPars<double> pod_d(const std::vector<double>& v) {
+        plant::FF16ProdPars<double> p;
+        p.lma=v[0];p.rho=v[1];p.theta=v[2];p.a_b1=v[3];p.a_r1=v[4];p.eta_c=v[5];
+        p.a_p1=v[6];p.a_p2=v[7];p.r_l=v[8];p.r_s=v[9];p.r_b=v[10];p.r_r=v[11];
+        p.k_l=v[12];p.k_b=v[13];p.k_s=v[14];p.k_r=v[15];p.a_bio=v[16];p.a_y=v[17];
+        return p;
+      }
+
+      // [[Rcpp::export]]
+      Rcpp::NumericVector ff16_netprod_grad(std::vector<double> v, double height,
+                                            double area_leaf, double light_E) {
+        using adt = xad::adj<double>::active_type;
+        xad::adj<double>::tape_type tape;
+        std::vector<adt> va(v.begin(), v.end());
+        adt h=height, al=area_leaf, le=light_E;
+        for (auto& x : va) tape.registerInput(x);
+        tape.registerInput(h); tape.registerInput(al); tape.registerInput(le);
+        tape.newRecording();
+        adt y = plant::ff16_net_mass_production_crown_top(pod_ad(va), h, al, le);
+        tape.registerOutput(y); xad::derivative(y)=1.0; tape.computeAdjoints();
+        Rcpp::NumericVector g(v.size()+3);
+        for (size_t i=0;i<v.size();++i) g[i]=xad::derivative(va[i]);
+        g[v.size()]=xad::derivative(h); g[v.size()+1]=xad::derivative(al);
+        g[v.size()+2]=xad::derivative(le);
+        return g;
+      }
+      // [[Rcpp::export]]
+      double ff16_netprod_value(std::vector<double> v, double height,
+                                double area_leaf, double light_E) {
+        return plant::ff16_net_mass_production_crown_top(pod_d(v), height, area_leaf, light_E);
+      }', verbose = FALSE)
+    NULL
+  }, error = function(e) e)
+  if (inherits(res, "error")) {
+    if (grepl("active_tape_", conditionMessage(res), fixed = TRUE))
+      testthat::skip("AD tape symbols unavailable in this load_all session.")
+    stop(res)
+  }
+}
+
+testthat::test_that("FF16 net-production AD gradient matches finite differences", {
+  testthat::skip_if(is_pkgload_dll_plant(),
+    "Skipping FF16 AD kernel in pkgload load_all sessions.")
+  compile_ff16_ad_kernel()
+
+  v <- c(0.1978791, 608, 0.0002141786, 0.17, 0.07, 0.5805, 151.177, 0.204,
+         0.01979, 0.0859, 0.04, 0.2086, 0.4565, 0.2, 0.0, 1.0, 0.0245, 0.7)
+  height <- 5; area_leaf <- 0.3; light_E <- 0.78
+
+  g <- ff16_netprod_grad(v, height, area_leaf, light_E)
+  inp <- c(v, height, area_leaf, light_E)
+  fd <- vapply(seq_along(inp), function(i) {
+    h <- 1e-6 * max(1, abs(inp[i]))
+    up <- inp; dn <- inp; up[i] <- up[i] + h; dn[i] <- dn[i] - h
+    f <- function(z) ff16_netprod_value(z[1:18], z[19], z[20], z[21])
+    (f(up) - f(dn)) / (2 * h)
+  }, numeric(1))
+
+  expect_equal(g, fd, tolerance = 1e-6)
+})

--- a/tests/testthat/test-ff16-deep-crown-ad.R
+++ b/tests/testthat/test-ff16-deep-crown-ad.R
@@ -1,0 +1,115 @@
+# Milestone B increment 1 (#472 scope B / #537): the deep-crown assimilation
+# integral as a frozen-replay weighted sum over an AD-capable resident light
+# spline. Validates that net production through the REAL default assimilation
+# variant differentiates correctly w.r.t. (a) a physiology trait (a_p1) and
+# (b) a stand trait `theta` that enters through the light spline's knot values
+# (the resident self-shading coupling) -- composing the FF16 kernel, odelia's
+# differentiable interpolator, and a frozen quadrature, all in one reverse sweep.
+
+is_pkgload_dll_plant <- function() {
+  loaded <- getLoadedDLLs()
+  if (!("plant" %in% names(loaded))) return(FALSE)
+  p <- tryCatch(loaded[["plant"]][["path"]], error = function(e) "")
+  is.character(p) && length(p) == 1 && grepl("pkgload", p, fixed = TRUE)
+}
+
+compile_ff16_deep_crown_ad <- function() {
+  plant_inc <- system.file("include", package = "plant")
+  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  odelia_inc <- system.file("include", package = "odelia")
+  odelia_so <- system.file("libs", "odelia.so", package = "odelia")
+  testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),
+                    "odelia shared library not found for tape linking.")
+  withr::local_envvar(
+    PKG_CPPFLAGS = paste(paste0("-I", shQuote(plant_inc)),
+                         paste0("-I", shQuote(odelia_inc))),
+    PKG_LIBS = shQuote(normalizePath(odelia_so)))
+
+  res <- tryCatch({
+    Rcpp::sourceCpp(code = '
+      #include <Rcpp.h>
+      #include <vector>
+      #include <cmath>
+      #include <XAD/XAD.hpp>
+      #include <odelia/interpolator.hpp>
+      #include <plant/models/ff16_production_kernel.h>
+
+      using adt = xad::adj<double>::active_type;
+
+      // theta enters the resident light spline knot values: y_i = exp(-theta*s_i).
+      template <typename S>
+      S net_with_deep_crown(S theta, S a_p1, double a_p2, double area_leaf,
+                            std::vector<double> xk, std::vector<double> shade,
+                            std::vector<double> z, std::vector<double> wq,
+                            double resp, double turn, double a_bio, double a_y) {
+        std::vector<S> yk(xk.size());
+        for (size_t i = 0; i < xk.size(); ++i) yk[i] = exp(-theta * shade[i]);
+        odelia::interpolator::basic_interpolator<S> light;
+        light.init(xk, yk);
+        S assim = plant::ff16_assimilation_deep_crown_replay<S>(
+            a_p1, S(a_p2), S(area_leaf), z, wq,
+            [&](double zz){ return light.eval(zz); });
+        return plant::ff16_net_production_A<S>(S(a_bio), S(a_y), assim, S(resp), S(turn));
+      }
+
+      // [[Rcpp::export]]
+      Rcpp::NumericVector deep_crown_grad(double theta, double a_p1, double a_p2,
+          double area_leaf, std::vector<double> xk, std::vector<double> shade,
+          std::vector<double> z, std::vector<double> wq, double resp, double turn,
+          double a_bio, double a_y) {
+        xad::adj<double>::tape_type tape;
+        adt th = theta, ap1 = a_p1;
+        tape.registerInput(th); tape.registerInput(ap1);
+        tape.newRecording();
+        adt y = net_with_deep_crown<adt>(th, ap1, a_p2, area_leaf, xk, shade, z, wq,
+                                         resp, turn, a_bio, a_y);
+        tape.registerOutput(y); xad::derivative(y) = 1.0; tape.computeAdjoints();
+        return Rcpp::NumericVector::create(xad::derivative(th), xad::derivative(ap1));
+      }
+      // [[Rcpp::export]]
+      double deep_crown_value(double theta, double a_p1, double a_p2,
+          double area_leaf, std::vector<double> xk, std::vector<double> shade,
+          std::vector<double> z, std::vector<double> wq, double resp, double turn,
+          double a_bio, double a_y) {
+        return net_with_deep_crown<double>(theta, a_p1, a_p2, area_leaf, xk, shade,
+                                           z, wq, resp, turn, a_bio, a_y);
+      }', verbose = FALSE)
+    NULL
+  }, error = function(e) e)
+  if (inherits(res, "error")) {
+    if (grepl("active_tape_", conditionMessage(res), fixed = TRUE))
+      testthat::skip("AD tape symbols unavailable in this load_all session.")
+    stop(res)
+  }
+}
+
+testthat::test_that("deep-crown frozen-replay assimilation differentiates (trait + light coupling)", {
+  testthat::skip_if(is_pkgload_dll_plant(),
+    "Skipping FF16 deep-crown AD in pkgload load_all sessions.")
+  compile_ff16_deep_crown_ad()
+
+  H <- 6
+  xk <- seq(0, H, length.out = 9)
+  shade <- 0.15 * (H - xk)               # taller canopy above -> more shade low down
+  # Frozen quadrature schedule (stand-in for the discovered crown integral):
+  # composite Simpson nodes/weights on [0,H], folding a leaf-density factor q(z).
+  nq <- 41
+  z <- seq(0, H, length.out = nq); dz <- H / (nq - 1)
+  simp <- ifelse(seq_len(nq) %in% c(1, nq), 1, ifelse(seq_len(nq) %% 2 == 0, 4, 2))
+  q <- pmax(0, 1 - z / H)                # leaf-area density weight, frozen
+  wq <- simp * dz / 3 * q
+
+  theta <- 0.8; a_p1 <- 151.177; a_p2 <- 0.204; area_leaf <- 0.3
+  resp <- 0.05; turn <- 0.08; a_bio <- 0.0245; a_y <- 0.7
+
+  g <- deep_crown_grad(theta, a_p1, a_p2, area_leaf, xk, shade, z, wq,
+                       resp, turn, a_bio, a_y)
+  f <- function(th, ap1) deep_crown_value(th, ap1, a_p2, area_leaf, xk, shade, z, wq,
+                                          resp, turn, a_bio, a_y)
+  h <- 1e-6
+  g_theta_fd <- (f(theta + h, a_p1) - f(theta - h, a_p1)) / (2 * h)
+  g_ap1_fd   <- (f(theta, a_p1 + h) - f(theta, a_p1 - h)) / (2 * h)
+
+  expect_equal(g[1], g_theta_fd, tolerance = 1e-6)  # through the light spline
+  expect_equal(g[2], g_ap1_fd, tolerance = 1e-6)    # through assimilation_leaf
+})

--- a/tests/testthat/test-ff16-deep-crown-ad.R
+++ b/tests/testthat/test-ff16-deep-crown-ad.R
@@ -14,8 +14,12 @@ is_pkgload_dll_plant <- function() {
 }
 
 compile_ff16_deep_crown_ad <- function() {
-  plant_inc <- system.file("include", package = "plant")
-  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  cand <- c(tryCatch(here::here("inst/include"), error = function(e) ""),
+            system.file("include", package = "plant"))
+  has_hdr <- file.exists(file.path(cand, "plant/models/ff16_production_kernel.h"))
+  testthat::skip_if(!any(has_hdr),
+                    "FF16 AD kernel header not found on include path.")
+  plant_inc <- cand[has_hdr][1]
   odelia_inc <- system.file("include", package = "odelia")
   odelia_so <- system.file("libs", "odelia.so", package = "odelia")
   testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),

--- a/tests/testthat/test-ff16-resident-coupling-ad.R
+++ b/tests/testthat/test-ff16-resident-coupling-ad.R
@@ -16,8 +16,12 @@ is_pkgload_dll_plant <- function() {
 }
 
 compile_ff16_resident_ad <- function() {
-  plant_inc <- system.file("include", package = "plant")
-  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  cand <- c(tryCatch(here::here("inst/include"), error = function(e) ""),
+            system.file("include", package = "plant"))
+  has_hdr <- file.exists(file.path(cand, "plant/models/ff16_production_kernel.h"))
+  testthat::skip_if(!any(has_hdr),
+                    "FF16 AD kernel header not found on include path.")
+  plant_inc <- cand[has_hdr][1]
   odelia_inc <- system.file("include", package = "odelia")
   odelia_so <- system.file("libs", "odelia.so", package = "odelia")
   testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),

--- a/tests/testthat/test-ff16-resident-coupling-ad.R
+++ b/tests/testthat/test-ff16-resident-coupling-ad.R
@@ -1,0 +1,122 @@
+# Milestone B increment 2 (#472 scope B / #537): the full resident self-shading
+# coupling. A trait flows through the templated FF16 area_leaf into BOTH (a) the
+# plant's own mass cascade + assimilation and (b) the competition it exerts,
+# which sets the resident light spline's knot values y_i = exp(-density * k_I *
+# area_leaf * Qfrac_i) (Beer's law; Qfrac_i = fraction of leaf above knot i, a
+# frozen geometric weight). Net production through the real deep-crown integral
+# over that AD light spline differentiates correctly w.r.t. a_l1 (everywhere) and
+# k_I (through the light only), in one reverse sweep -- composing the FF16 kernel,
+# odelia's differentiable interpolator, and a frozen quadrature.
+
+is_pkgload_dll_plant <- function() {
+  loaded <- getLoadedDLLs()
+  if (!("plant" %in% names(loaded))) return(FALSE)
+  p <- tryCatch(loaded[["plant"]][["path"]], error = function(e) "")
+  is.character(p) && length(p) == 1 && grepl("pkgload", p, fixed = TRUE)
+}
+
+compile_ff16_resident_ad <- function() {
+  plant_inc <- system.file("include", package = "plant")
+  if (!nzchar(plant_inc)) plant_inc <- here::here("inst/include")
+  odelia_inc <- system.file("include", package = "odelia")
+  odelia_so <- system.file("libs", "odelia.so", package = "odelia")
+  testthat::skip_if(!nzchar(odelia_so) || !file.exists(odelia_so),
+                    "odelia shared library not found for tape linking.")
+  withr::local_envvar(
+    PKG_CPPFLAGS = paste(paste0("-I", shQuote(plant_inc)),
+                         paste0("-I", shQuote(odelia_inc))),
+    PKG_LIBS = shQuote(normalizePath(odelia_so)))
+
+  res <- tryCatch({
+    Rcpp::sourceCpp(code = '
+      #include <Rcpp.h>
+      #include <vector>
+      #include <cmath>
+      #include <XAD/XAD.hpp>
+      #include <odelia/interpolator.hpp>
+      #include <plant/models/ff16_production_kernel.h>
+      using adt = xad::adj<double>::active_type;
+
+      template <typename S>
+      S resident_net(S a_l1, S k_I, const plant::FF16ProdPars<S>& p,
+                     double a_l2, double height, double density,
+                     std::vector<double> xk, std::vector<double> qfrac_knot,
+                     std::vector<double> z, std::vector<double> wq) {
+        S area_leaf = plant::ff16_area_leaf<S>(a_l1, S(a_l2), S(height));
+        // Resident light spline: Beer\'s law over its own competition.
+        std::vector<S> yk(xk.size());
+        for (size_t i = 0; i < xk.size(); ++i)
+          yk[i] = exp(-density * k_I * area_leaf * qfrac_knot[i]);
+        odelia::interpolator::basic_interpolator<S> light;
+        light.init(xk, yk);
+        S assim = plant::ff16_assimilation_deep_crown_replay<S>(
+            p.a_p1, p.a_p2, area_leaf, z, wq,
+            [&](double zz){ return light.eval(zz); });
+        return plant::ff16_net_from_components<S>(p, S(height), area_leaf, assim);
+      }
+
+      template <typename S>
+      plant::FF16ProdPars<S> mkpod(std::vector<double> v) {
+        plant::FF16ProdPars<S> p;
+        p.lma=v[0];p.rho=v[1];p.theta=v[2];p.a_b1=v[3];p.a_r1=v[4];p.eta_c=v[5];
+        p.a_p1=v[6];p.a_p2=v[7];p.r_l=v[8];p.r_s=v[9];p.r_b=v[10];p.r_r=v[11];
+        p.k_l=v[12];p.k_b=v[13];p.k_s=v[14];p.k_r=v[15];p.a_bio=v[16];p.a_y=v[17];
+        return p;
+      }
+
+      // [[Rcpp::export]]
+      Rcpp::NumericVector resident_grad(double a_l1, double k_I, std::vector<double> v,
+          double a_l2, double height, double density, std::vector<double> xk,
+          std::vector<double> qfrac_knot, std::vector<double> z, std::vector<double> wq) {
+        xad::adj<double>::tape_type tape;
+        adt al1 = a_l1, ki = k_I;
+        tape.registerInput(al1); tape.registerInput(ki);
+        tape.newRecording();
+        adt y = resident_net<adt>(al1, ki, mkpod<adt>(v), a_l2, height, density,
+                                  xk, qfrac_knot, z, wq);
+        tape.registerOutput(y); xad::derivative(y) = 1.0; tape.computeAdjoints();
+        return Rcpp::NumericVector::create(xad::derivative(al1), xad::derivative(ki));
+      }
+      // [[Rcpp::export]]
+      double resident_value(double a_l1, double k_I, std::vector<double> v,
+          double a_l2, double height, double density, std::vector<double> xk,
+          std::vector<double> qfrac_knot, std::vector<double> z, std::vector<double> wq) {
+        return resident_net<double>(a_l1, k_I, mkpod<double>(v), a_l2, height, density,
+                                    xk, qfrac_knot, z, wq);
+      }', verbose = FALSE)
+    NULL
+  }, error = function(e) e)
+  if (inherits(res, "error")) {
+    if (grepl("active_tape_", conditionMessage(res), fixed = TRUE))
+      testthat::skip("AD tape symbols unavailable in this load_all session.")
+    stop(res)
+  }
+}
+
+testthat::test_that("FF16 resident self-shading coupling differentiates end-to-end", {
+  testthat::skip_if(is_pkgload_dll_plant(),
+    "Skipping FF16 resident-coupling AD in pkgload load_all sessions.")
+  compile_ff16_resident_ad()
+
+  H <- 8; density <- 1.5
+  xk <- seq(0, H, length.out = 11)
+  qfrac_knot <- pmax(0, 1 - xk / H)        # leaf-above fraction at each spline knot
+  nq <- 41; z <- seq(0, H, length.out = nq); dz <- H / (nq - 1)
+  simp <- ifelse(seq_len(nq) %in% c(1, nq), 1, ifelse(seq_len(nq) %% 2 == 0, 4, 2))
+  q <- pmax(0, 1 - z / H)
+  wq <- simp * dz / 3 * q
+
+  a_l1 <- 0.306; a_l2 <- 0.75; k_I <- 0.5
+  v <- c(0.1978791, 608, 0.0002141786, 0.17, 0.07, 0.5805, 151.177, 0.204,
+         0.01979, 0.0859, 0.04, 0.2086, 0.4565, 0.2, 0.0, 1.0, 0.0245, 0.7)
+
+  g <- resident_grad(a_l1, k_I, v, a_l2, H, density, xk, qfrac_knot, z, wq)
+  f <- function(al1, ki) resident_value(al1, ki, v, a_l2, H, density, xk,
+                                        qfrac_knot, z, wq)
+  h <- 1e-6
+  g_al1_fd <- (f(a_l1 + h, k_I) - f(a_l1 - h, k_I)) / (2 * h)
+  g_kI_fd  <- (f(a_l1, k_I + h) - f(a_l1, k_I - h)) / (2 * h)
+
+  expect_equal(g[1], g_al1_fd, tolerance = 1e-6)  # a_l1: area_leaf -> everything
+  expect_equal(g[2], g_kI_fd, tolerance = 1e-6)   # k_I: through the light spline only
+})


### PR DESCRIPTION
First slice of end-to-end AD for FF16 (#472 scope B; inventory/plan #537),
building on the differentiable spline merged in traitecoevo/odelia#32. Additive
and non-breaking: a scalar-templated header kernel that FF16's `double` methods
**delegate** to, so the existing FF16 suite — including the bit-identical
reference-comparison test — validates faithfulness (no drift, no perf change to
the production path).

## What's here

- **`ff16_production_kernel.h`** — the FF16 single-plant net-production chain
  [eqn 2, 12–15] templated on a scalar `S`: `ff16_area_leaf`,
  `ff16_assimilation_leaf`, `ff16_respiration`, `ff16_turnover`,
  `ff16_net_production_A`, `ff16_net_from_components`, and the crown-top /
  deep-crown net-production entry points.
- **Delegation** — `FF16_Strategy::{area_leaf, assimilation_leaf, respiration,
  turnover, net_mass_production_dt_A}` now call the kernel (single source of
  truth). `S = double` is the unchanged production path.
- **Deep-crown as frozen replay** — `ff16_assimilation_deep_crown_replay<S>`: the
  default crown integral as a fixed weighted sum over recorded nodes (the
  adaptive QK schedule is discovered once in `double` and replayed; the
  leaf-density `q` folds into the frozen weight). `light` is any callable
  `z -> S`, e.g. odelia's AD `basic_interpolator<S>`.

## Validation (reverse-mode AD vs central FD)

- **Milestone A** — net production differentiates w.r.t. **18 traits + height +
  light** in one reverse sweep, ~1e-8 (`test-ff16-ad-kernel.R`).
- **Deep-crown over the AD light spline** — ~1e-9 w.r.t. a physiology trait and a
  light-coupling trait (`test-ff16-deep-crown-ad.R`).
- **Resident self-shading** — a trait flows through `area_leaf` into both the
  plant's production *and* the competition it exerts (light knot values), ~4e-11
  w.r.t. `a_l1` (everywhere) and `k_I` (light only)
  (`test-ff16-resident-coupling-ad.R`).
- **No regression** — full suite `FAIL 0`; FF16 reference comparison bit-identical.

AD tests link the XAD tape from odelia's `.so` (the established odelia AD-test
recipe); they skip under `load_all` and run on the installed package in CI.

## Scope / what's deferred

Crown-top + frozen-replay deep-crown assimilation only (the adaptive QK and
spline *schedules* are discovered in `double` and replayed — not differentiated).
The composition is currently driven by hand-built light splines/quadrature in the
tests; wiring it through the **live `Patch`/`Environment`/`Individual`** objects
(templating those on `S`) and the SCM is the next milestone (the shared `<T,E>`
hierarchy + ODE-state boundary). `FF16_Pars` is not templated here — traits are
passed via `FF16ProdPars<S>`; full param/class templating follows with the
hierarchy work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)