### PR TITLE
Adopt plant-meta governance (board auto-add + cross-package pointer)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -57,3 +57,12 @@ When opening an issue (including whenever the user asks you to create one), alwa
 
 Create issues with `gh issue create -R traitecoevo/plant --title "[tag] …"
 --label task` (swap in `bug`/`epic` as appropriate).
+
+## Cross-package context
+
+This repo is part of the **plant family** in the `traitecoevo` org (the core individual-based forest model). For
+cross-package orientation — how the family fits together, dependency direction,
+source-of-truth rules, and the shared label/board conventions — see
+**[`plant-meta`](https://github.com/traitecoevo/plant-meta)** (start with its
+`AGENTS.md`). Don't restate family-wide concerns here; link to plant-meta and
+keep this file about `plant`-local matters.

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,83 +1,12 @@
-name: Add issues to project
-
+name: Add new issues to plant board #5
 on:
   issues:
     types: [opened]
-
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue to project
-        uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/traitecoevo/projects/5
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-
-      - name: Label issue as task (only if opened with no label)
-        if: ${{ github.event.issue.labels[0] == null }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['task'],
-            });
-
-      - name: Set project status to Backlog
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
-          script: |
-            const issueNodeId = context.payload.issue.node_id;
-
-            // Find the project item for this issue
-            const itemResult = await github.graphql(`
-              query($nodeId: ID!) {
-                node(id: $nodeId) {
-                  ... on Issue {
-                    projectItems(first: 10) {
-                      nodes { id project { id number } }
-                    }
-                  }
-                }
-              }`, { nodeId: issueNodeId });
-
-            const item = itemResult.node.projectItems.nodes.find(n => n.project.number === 5);
-            if (!item) return;
-
-            // Get Status field and Backlog option IDs
-            const projectResult = await github.graphql(`
-              query {
-                organization(login: "traitecoevo") {
-                  projectV2(number: 5) {
-                    fields(first: 20) {
-                      nodes {
-                        ... on ProjectV2SingleSelectField {
-                          id name options { id name }
-                        }
-                      }
-                    }
-                  }
-                }
-              }`);
-
-            const fields = projectResult.organization.projectV2.fields.nodes;
-            const statusField = fields.find(f => f.name === 'Status');
-            const backlogOption = statusField?.options.find(o => o.name.toLowerCase() === 'backlog');
-            if (!statusField || !backlogOption) return;
-
-            await github.graphql(`
-              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-                updateProjectV2ItemFieldValue(input: {
-                  projectId: $projectId itemId: $itemId fieldId: $fieldId
-                  value: { singleSelectOptionId: $optionId }
-                }) { projectV2Item { id } }
-              }`, {
-              projectId: item.project.id,
-              itemId: item.id,
-              fieldId: statusField.id,
-              optionId: backlogOption.id,
-            });


### PR DESCRIPTION
Adopts the shared **plant-family governance** maintained in [`plant-meta`](https://github.com/traitecoevo/plant-meta).

**This PR:**
- Adds/normalises `.github/workflows/add-to-project.yml` so new issues auto-add to [board #5](https://github.com/orgs/traitecoevo/projects/5). New issues land with **no Status** = the triage queue (the family convention — no auto-label, no auto-Backlog).
- Adds a *Cross-package context* pointer to plant-meta in `.claude/CLAUDE.md`.

**⚠️ Prerequisite before merging:** the org secret `ADD_TO_PROJECT_PAT` (a token with Projects read/write) must exist, or the workflow run will fail. See [auto-add-to-board.md](https://github.com/traitecoevo/plant-meta/blob/main/governance/auto-add-to-board.md).

Draft — this replaces any prior auto-add workflow with the simpler triage-convention version; review before marking ready.