### PR TITLE
Replace loggr with logger for CRAN-compatible logging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ LinkingTo: Rcpp, BH, odelia
 Imports:
     Rcpp,
     R6,
-    loggr,
+    logger,
     crayon,
     magrittr,
     tibble,
@@ -49,7 +49,6 @@ Suggests:
     patchwork,
     kableExtra
 Remotes:
-    smbache/loggr,
     richfitz/RcppR6,
     traitecoevo/odelia
 URL: https://github.com/traitecoevo/plant

--- a/R/logging.R
+++ b/R/logging.R
@@ -1,73 +1,63 @@
-## Standard fields:
+## Log fields included in output:
 ##
-## * time    (done in loggr)
-## * level   (done in loggr)
-## * package (done here)
-## * pid     (done here)
-## * routine {equilibrium, schedule, ...}
-## * stage   (start, converged, etc.)
-plant_log_info <- function(...) {
-  loggr::log_info(..., package="plant", pid=Sys.getpid())
+## * time    (from logger)
+## * level   (from logger)
+## * routine {equilibrium, viable, inviable, ...}
+plant_log_info <- function(message, routine=NULL, ...) {
+  if (!is.null(routine)) message <- paste0(crayon::yellow(routine), "> ", message)
+  logger::log_info(message, namespace="plant", .topenv=parent.frame())
 }
 
-plant_log_debug <- function(...) {
-  loggr::log_debug(..., package="plant", pid=Sys.getpid())
+plant_log_debug <- function(message, routine=NULL, ...) {
+  if (!is.null(routine)) message <- paste0(crayon::yellow(routine), "> ", message)
+  logger::log_debug(message, namespace="plant", .topenv=parent.frame())
 }
 
+plant_log_eq <- function(...) {
+  plant_log_info(..., routine="equilibrium")
+}
 
-make_plant_format_log_entry <- function(colour) {
-  if (colour) {
-    col_routine <- crayon::yellow
-    col_time    <- crayon::silver
-  } else {
-    col_routine <- col_time <- identity
-  }
-  function(event) {
-    if (is.null(event$routine)) {
-      msg <- event$message
-    } else {
-      msg <- sprintf("%s> %s", col_routine(event$routine), event$message)
-    }
+plant_log_viable <- function(...) {
+  plant_log_info(..., routine="viable")
+}
+
+plant_log_inviable <- function(...) {
+  plant_log_info(..., routine="inviable")
+}
+
+make_plant_layout <- function(colour=TRUE) {
+  col_time <- if (colour) crayon::silver else identity
+  function(level, msg, namespace, .logcall, .topcall, .topenv, .timestamp=Sys.time()) {
     sprintf("[%s] %s",
-            col_time(format(event$time, "%Y-%m-%d %H:%M:%OS3")),
-            msg)
+            col_time(format(.timestamp, "%H:%M:%OS3")),
+            paste(msg, collapse=" "))
   }
 }
 
-##' Activate logging with loggr
+##' Activate logging
 ##'
 ##' By default plant prints little information about its progress.
-##' This can be modified by enabling logging.  A formatter that is
-##' different to the default \code{loggr::log_file} formatter is
-##' selected here; it will print additional information that plant's
-##' internal logging functions record.
+##' This can be modified by enabling logging.  Log entries include a
+##' timestamp and, where applicable, a routine label indicating which
+##' part of the model is running.
 ##'
 ##' "Schedule" events (splitting) are sent to the DEBUG stream,
-##' everything else is sent to INFO.  All events have a "routine"
-##' field added to them, which is useful if sent to a Redis server
-##' (using \code{loggr.redis}).
-##' @title Activate logging with loggr
-##' @param ... Additional parameters passed to \code{loggr::log_file},
-##' but \emph{not} \code{file_name} which is hard coded here to
-##' \code{"console"}.
-##' @param file_name File to save output (default = console)
-##' @param .message,.warning,.error Include messages, warnings or
-##' errors?  By default (and in contrast to \code{loggr::log_file}
-##' these are disabled here.
+##' everything else is sent to INFO.
+##' @title Activate logging
+##' @param file_name File to save output (default = "console")
+##' @param colour Use colour in console output?
+##' @param threshold Minimum log level to emit: "DEBUG", "INFO", etc.
 ##' @export
-plant_log_console <- function(file_name="console",
-                              .message=FALSE,
-                              .warning=FALSE,
-                              .error=FALSE,
-                              ...) {
-  loggr::log_file(file_name, ...,
-                  .message=.message,
-                  .warning=.warning,
-                  .error=.error,
-                  .formatter=make_plant_format_log_entry(TRUE))
+plant_log_console <- function(file_name="console", colour=TRUE, threshold="INFO") {
+  logger::log_threshold(threshold, namespace="plant")
+  if (file_name == "console") {
+    logger::log_appender(logger::appender_console, namespace="plant")
+  } else {
+    logger::log_appender(logger::appender_file(file_name), namespace="plant")
+  }
+  logger::log_layout(make_plant_layout(colour), namespace="plant")
 }
 
-## There would be no need for this though; we'd just pass through directly:
-## plant_log_redis <- function(con, key, ...) {
-##   loggr.redis::log_redis(con, key, ...)
-## }
+.onLoad <- function(libname, pkgname) {
+  logger::log_threshold(logger::OFF, namespace="plant")
+}


### PR DESCRIPTION
## Summary

- Replaces the unmaintained `loggr` (GitHub-only) dependency with [`logger`](https://github.com/daroczig/logger), which is actively maintained and on CRAN
- Rewrites `R/logging.R` to use `logger` namespaces, appenders, and a custom layout
- Adds `.onLoad` so plant is silent by default; `plant_log_console()` activates logging as before
- `plant_log_console()` gains `colour` and `threshold` args; drops loggr-specific `.message`/`.warning`/`.error` params

Output format:
```
[11:03:10.728] assembler> Starting empty assembler
[11:03:10.736] births> Adding new resident type
```

Only two files changed: `R/logging.R` and `DESCRIPTION`.

Closes #276

## Test plan

- [ ] Install `logger` from CRAN and load package
- [ ] Confirm plant is silent without calling `plant_log_console()`
- [ ] Call `plant_log_console()` and confirm timestamped output appears
- [ ] Call `plant_log_console(threshold = "DEBUG")` and confirm debug messages appear
- [ ] Call `plant_log_console(file_name = "out.log")` and confirm file is written

🤖 Generated with [Claude Code](https://claude.ai/claude-code)