### PR TITLE
fix: QK integrator fails fast on NaN (#268)

### DIFF
--- a/inst/include/plant/qk.h
+++ b/inst/include/plant/qk.h
@@ -12,8 +12,9 @@
 #define PLANT_PLANT_QK_H_
 
 #include <vector>
-#include <cmath> // std::abs
+#include <cmath> // std::abs, std::isnan
 #include <RcppCommon.h> // SEXP
+#include <plant/util.h> // util::stop
 
 namespace plant {
 namespace quadrature {
@@ -63,6 +64,9 @@ double QK::integrate(Function f, double a, double b) {
   const double half_length     = 0.5 * (b - a);
   const double abs_half_length = std::abs(half_length);
   const double f_center        = f(center);
+  if (std::isnan(f_center)) {
+    util::stop("Integrand returned NaN at x=" + std::to_string(center));
+  }
 
   double result_gauss = 0;
   double result_kronrod = f_center * wgk[n - 1];
@@ -117,6 +121,11 @@ double QK::integrate(Function f, double a, double b) {
   last_result_abs = result_abs;
   last_result_asc = result_asc;
   last_error      = rescale_error(err, result_abs, result_asc);
+
+  if (std::isnan(last_result)) {
+    util::stop("Integrand produced NaN result over [" +
+               std::to_string(a) + ", " + std::to_string(b) + "]");
+  }
 
   return last_result;
 }

--- a/tests/testthat/test-qag.R
+++ b/tests/testthat/test-qag.R
@@ -166,6 +166,14 @@ test_that("Remembering intervals works", {
   expect_equal(tmp_scal, tmp * b1 / b)
 })
 
+test_that("NaN-returning integrand errors immediately, not 'Maximum subdivisions'", {
+  f_nan <- function(x) NaN
+  int <- QAG(15, 100, 1e-8, 1e-8)
+  msg <- tryCatch(int$integrate(f_nan, 0, 1), error = function(e) conditionMessage(e))
+  expect_match(msg, "NaN")
+  expect_false(grepl("Maximum number of subdivisions", msg))
+})
+
 test_that("Non-adaptive integration works", {
   f <- function(x) 2^sin(sqrt(x))
   a <- 0

--- a/tests/testthat/test-qk.R
+++ b/tests/testthat/test-qk.R
@@ -48,6 +48,12 @@ test_that("Cannot make non-existent rules", {
   expect_error(QK(NA), "Unknown rule")
 })
 
+test_that("NaN-returning integrand errors immediately", {
+  f_nan <- function(x) NaN
+  int <- QK(15)
+  expect_error(int$integrate(f_nan, 0, 1), "NaN")
+})
+
 test_that("Vectorised interface to integration works", {
   int_15 <- QK(15)
   x <- int_15$integrate_vector_x(a, b)


### PR DESCRIPTION
## Summary

- Closes #268
- `QK::integrate` now calls `util::stop` immediately if the integrand returns NaN, rather than letting the adaptive loop exhaust its subdivision limit and emit the misleading "Maximum number of subdivisions reached" error
- Two checks: one right after `f_center = f(center)` (reports offending x), one after accumulating `result_kronrod` (reports interval `[a, b]`)
- Covers both adaptive and fixed integration modes since `QK::integrate` is the shared path

## Test plan

- [ ] Confirm a NaN-returning integrand now throws a descriptive error rather than "Maximum number of subdivisions reached"
- [ ] Existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)