### PR TITLE
fix: graceful failure on SCM cohort-density blow-up (#550)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -184,6 +184,13 @@ were not previously recorded here:
 
 ### Minor changes & bug fixes
 
+* `run_scm()` now fails with an actionable message when the SCM size-density
+  (characteristic) equations run away under extreme forcing (e.g. severe
+  seasonal drought in TF24): a cohort density overflowing to `+Inf`, or the
+  density-weighted resource uptake driving a soil-water state non-finite. The
+  guard fires each ODE step, before the non-finite value propagates into the
+  competition integral or physiology, replacing the previous opaque
+  `Detected non-finite contribution` / `non-finite psi_soil` errors (#550).
 * `Node` now records its introduction time and patch-age density at the moment
   it is introduced, so reproduction and integration-error calculations no longer
   re-derive these from the node schedule / disturbance regime after the run.

--- a/inst/include/plant/node.h
+++ b/inst/include/plant/node.h
@@ -62,6 +62,9 @@ public:
 
   // Unfortunate, but need a get_ here because of name shadowing...
   double get_log_density() const {return log_density;}
+  // exp(log_density); can overflow to +Inf when the SCM density equation runs
+  // away (see Patch::check_finite_node_densities).
+  double get_density() const {return density;}
   void set_log_density(double x) {
     log_density = x;
     density = exp(log_density);

--- a/inst/include/plant/patch.h
+++ b/inst/include/plant/patch.h
@@ -171,6 +171,12 @@ private:
   // Guard against initial conditions whose per-node log-density rates are so
   // large they would drive densities to non-finite values within a few steps.
   void check_initial_density_rates() const;
+  // Guard against the SCM equations running away mid-integration: a cohort
+  // density (exp(log_density)) or an environment state (e.g. TF24 soil water)
+  // going non-finite. Called each derivs evaluation, before the non-finite
+  // value can propagate into competition, resource uptake, or physiology and
+  // surface as an opaque downstream error.
+  void check_finite_ode_state() const;
 
   parameters_type parameters;
 
@@ -341,6 +347,75 @@ void Patch<T,E>::check_initial_density_rates() const {
       util::stop("Rates of initial node densities exceed ~1e43 and will likely "
                  "produce non-finite densities; provide more plausible initial "
                  "conditions (smaller sizes and/or lower densities).");
+    }
+  }
+}
+
+template <typename T, typename E>
+void Patch<T,E>::check_finite_ode_state() const {
+  // The two failure modes of the same runaway (issue #550), caught here so they
+  // fail with an actionable message instead of an opaque downstream one:
+  //
+  //  (1) A cohort density overflowing to +Inf, which then poisons the
+  //      competition integral ("Detected non-finite contribution").
+  //  (2) The coupled environment state (TF24 soil water) going non-finite,
+  //      because the density-weighted resource uptake diverges as density
+  //      grows; the RK stage arithmetic can produce a non-finite soil state a
+  //      step before density itself overflows, surfacing as a non-finite soil
+  //      potential ("non-finite psi_soil").
+  //
+  // Density ceiling (~1e43): the same "already unphysical, will drive
+  // non-finite values" bar used by check_initial_density_rates. Catching the
+  // runaway at this magnitude -- before density reaches a literal +Inf --
+  // widens coverage of mode (1) and heads off some instances of mode (2).
+  const double log_density_ceiling = 50.0;
+  for (size_t i = 0; i < species.size(); ++i) {
+    for (auto it = species[i].node_begin(); it != species[i].node_end(); ++it) {
+      if (!util::is_finite(it->get_density()) ||
+          it->get_log_density() > log_density_ceiling) {
+        // The size-density characteristic equation integrates
+        //   d(log density)/dt = -d(growth)/d(height) - mortality
+        // (see Node::compute_rates). When growth rate falls steeply with size
+        // -- e.g. a cohort hitting an extreme drought trough -- the gradient
+        // term can spike sharply positive, so log_density integrates upward
+        // until density = exp(log_density) overflows to +Inf. The individual's
+        // physiology (height, leaf area, per-individual competition) stays
+        // finite; it is the cohort *density* that blows up. Smaller ODE steps
+        // do not help (the divergence is in the equations, not the stepper), so
+        // fail here with an actionable message rather than letting the +Inf
+        // propagate into the competition integral or density-weighted resource
+        // uptake, where it surfaces as an opaque downstream error.
+        util::stop("Non-finite cohort density in the SCM size-density "
+                   "(characteristic) equations: species " +
+                   util::to_string(i + 1) + " has a node with density=" +
+                   util::to_string(it->get_density()) + " (log_density=" +
+                   util::to_string(it->get_log_density()) + ", height=" +
+                   util::to_string(it->height()) + ") at time=" +
+                   util::to_string(environment.time) +
+                   ". The density derivative -d(growth)/d(height) - mortality "
+                   "can grow without bound when growth rate falls steeply with "
+                   "size under rapidly changing or extreme environmental "
+                   "forcing, driving density to overflow. Try a shorter "
+                   "max_patch_lifetime or less extreme environmental drivers.");
+      }
+    }
+  }
+
+  // Mode (2): a non-finite environment state. `vars.states` is generic across
+  // environments (size 0 for light-only environments like FF16, so this loop is
+  // a no-op there and cannot false-positive). For TF24 these are the per-depth
+  // soil-water states.
+  const Internals& env_vars = environment.vars;
+  for (size_t i = 0; i < env_vars.state_size; ++i) {
+    if (!util::is_finite(env_vars.states[i])) {
+      util::stop("Non-finite environment state (index " + util::to_string(i) +
+                 " = " + util::to_string(env_vars.states[i]) + ") at time=" +
+                 util::to_string(environment.time) +
+                 ". For TF24 this is a soil-water state driven non-finite by the "
+                 "density-weighted resource uptake as a cohort density runs away "
+                 "in the SCM size-density equations (the same failure that "
+                 "otherwise overflows density to +Inf; see #550). Try a shorter "
+                 "max_patch_lifetime or less extreme environmental drivers.");
     }
   }
 }
@@ -611,6 +686,11 @@ odelia::ode::const_iterator Patch<T,E>::set_ode_state(odelia::ode::const_iterato
 
   // update time
   environment.time = time;
+
+  // Catch a runaway size-density equation (non-finite cohort density or
+  // environment state) before it feeds into competition, resource uptake, or
+  // physiology below and surfaces as an opaque downstream error (issue #550).
+  check_finite_ode_state();
 
   // Pre-compute environment, as shaped by residents
   compute_environment(true);

--- a/tests/testthat/test-strategy-tf24.R
+++ b/tests/testthat/test-strategy-tf24.R
@@ -330,3 +330,27 @@ results$env$soil_moist_cumulative_flux %>%
 expect_true(1 - (stem_side/root_side$root_side[-1])[length(stem_side)] < 5e-2)
 })
 
+test_that("SCM cohort-density blow-up fails gracefully (#550)", {
+  # Extreme seasonal drought drives the SCM size-density (characteristic)
+  # equations to run away: a cohort density overflows to +Inf, or the
+  # density-weighted resource uptake drives a soil-water state non-finite.
+  # Either way run_scm must abort with an actionable message naming the SCM
+  # size-density equations / environment state, not an opaque downstream error
+  # ("Detected non-finite contribution", "non-finite psi_soil"). This blows up
+  # early in the run, so it is cheap despite being a full TF24 run.
+  mpl <- 30
+  p0 <- scm_base_parameters("TF24", "TF24_Env")
+  p0$max_patch_lifetime <- mpl
+  p1 <- add_strategies(p0, trait_matrix(0.07, "lma"))
+
+  env <- Environment("TF24")
+  env$set_soil_number_of_depths(5)
+  env$set_soil_water_state(rep(0.2, 5))
+  x <- seq(0, mpl, length.out = mpl * 6)
+  y <- 0.4 * sin(2 * pi * x) + 0.5   # rainfall sweeps [0.1, 0.9]
+  env$extrinsic_drivers_set_variable("rainfall", x = x, y = y)
+
+  expect_error(run_scm(p1, env),
+               "SCM size-density|Non-finite environment state")
+})
+


### PR DESCRIPTION
## Summary

Graceful-failure guard for the SCM cohort-density blow-up under extreme seasonal drought (#550). This does **not** make the affected runs complete — trustworthy completion is blocked on the model (NSC buffering #517 / the hydraulic-optimum discontinuity #551). It converts the previously opaque downstream crashes into a clear, early, actionable error naming the actual cause.

Full investigation report: https://github.com/traitecoevo/plant/issues/550#issuecomment-4853698744

## The bug

The SCM size-density (characteristic) equation `d(log density)/dt = -dg/dh - mortality` runs away at the first deep drought trough: a cohort's growth rate collapses steeply with size, `dg/dh` spikes near-singular, `log_density` integrates up, and `density = exp(log_density)` overflows to `+Inf`. The individual physiology stays finite — it's the cohort *density* that blows up. It surfaced as one of two errors far from the cause:

- `Detected non-finite contribution` — `+Inf` density poisoning the competition integral, or
- `non-finite psi_soil` — the density-weighted uptake driving the soil-water ODE non-finite a step before density overflows.

Not a stepper artifact: identical failure under tight tolerances, capped step, and fixed-step Euler.

## What this PR does

Adds `Patch::check_finite_ode_state()`, called each derivs evaluation from `set_ode_state` *before* the state feeds competition / resource uptake / physiology. It stops with a descriptive message when:

- a cohort density is non-finite or exceeds ~1e43 (the same unphysical bar as the existing `check_initial_density_rates`), or
- an environment ODE state is non-finite (generic via `environment.vars.states`; size 0 for light-only environments like FF16, so it's a no-op there and cannot false-positive).

The message names the SCM size-density equations / soil-water state, reports the offending species/density/height/time, and suggests a shorter `max_patch_lifetime` or less extreme drivers. Both previous failure routes now report the same root cause.

Also adds a `Node::get_density()` accessor, a TF24 regression test, and a NEWS entry.

## Testing

- New regression test (`test-strategy-tf24.R`): the drought regime now aborts with the descriptive error.
- `test-patch`, `test-scm`, `test-scm-support`, `test-environment-TF24`, `test-strategy-tf24` all pass — no regressions, and healthy runs (`mpl=10/13`, FF16/standard TF24) are unchanged.

## Scope / follow-ups

- Does **not** attempt to make blow-up regimes complete. We tried growth-cutoff smoothing, a mortality cap, and a density-rate limiter; none give trustworthy completion (see the #550 report). Those experiments are not included here.
- Root-cause follow-ups: #551 (hydraulic-optimum continuity) and #517 (NSC buffering).

Closes #550 (as "graceful failure", the fallback in the issue's acceptance criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
