### PR TITLE
[AutoDiff] docs: add AD design notes

### DIFF
--- a/notes/ad-design/README.md
+++ b/notes/ad-design/README.md
@@ -1,4 +1,4 @@
-# AD infrastructure roadmap (plant × odelia)
+# AD infrastructure design (plant × odelia)
 
 **What.** A design for computing exact **trait gradients** of the `plant` SCM's
 emergent outputs — how stand properties (LAI, biomass, basal area, offspring
@@ -7,28 +7,27 @@ production) respond to plant traits — by **automatic differentiation (AD)**, b
 
 **Why.** A validated prototype exists
 ([traitecoevo/plant#553](https://github.com/traitecoevo/plant/pull/553), tracking
-issue [#472](https://github.com/traitecoevo/plant/issues/472)) but rebuilt inside
-plant machinery that odelia already provides. This roadmap reaches the same gradients
-with **surgical changes** to the existing plant components and a **small generic
-surface** added to odelia — smaller, more maintainable, lower technical debt.
-
-**Status.** Design phase — no code changes yet. Branches
-`claude/ad-infrastructure-design` are prepared on the plant and odelia forks for the
-eventual implementation.
+issue [#472](https://github.com/traitecoevo/plant/issues/472)). The design reaches the
+same gradients with **surgical changes** to the plant components that already exist and
+a **small generic surface** on odelia — because the Patch is already the odelia System
+and `run_mutant` is already the frozen-schedule replay.
 
 ---
 
 ## Read in this order
 
 1. **[`ad-infrastructure-design.md`](./ad-infrastructure-design.md)** — the design.
-   The thesis, the settled decisions, the three layers (odelia / plant / UX), the
-   surgical changes, the two workflows, and the four replay levels. Start here.
-2. **[`ad-r-interface.md`](./ad-r-interface.md)** — the R/C++ boundary: why XAD types
+   The thesis, the decisions, the three layers (odelia / plant / UX), the surgical
+   changes, the two workflows, and the four replay levels. Start here.
+2. **[`ad-record-replay.md`](./ad-record-replay.md)** — the one adaptive-numerics
+   primitive under the replay levels: record where the adaptive pass placed its nodes,
+   replay pinned to them with the active scalar.
+3. **[`ad-r-interface.md`](./ad-r-interface.md)** — the R/C++ boundary: why XAD types
    are awkward through Rcpp, the "only doubles cross" invariant, and **user stories**
-   for each persona. Read after the design.
-3. **[`ad-issues.md`](./ad-issues.md)** — the work breakdown: scoped items
-   (odelia / plant / R-boundary / prototypes), dependencies, and a critical-path
-   build order. Read when planning implementation.
+   for each persona.
+
+[`ad-issues.md`](./ad-issues.md) is the separate work breakdown — scoped items,
+dependencies, and build order — not part of the design proper.
 
 ---
 
@@ -63,13 +62,13 @@ For a reader new to the model or to AD. Fuller treatment is in the design doc.
 - **Replay levels (L0–L3)** — the SCM has several *adaptive* constructions (the node
   schedule, the ODE step sizes, the light interpolator, the crown quadrature). AD
   needs each frozen to its recorded placement so the result is differentiable. The
-  key idea (design §7.5): run once adaptively, **record where the nodes landed, replay
-  on them fixed** with the active scalar.
+  key idea (see [`ad-record-replay.md`](./ad-record-replay.md)): run once adaptively,
+  **record where the nodes landed, replay on them fixed** with the active scalar.
 - **odelia** — the family's AD-aware ODE runtime: compiles XAD once, ships a
   scalar-templated `Solver`, a reverse-mode gradient driver, and a differentiable
   spline. plant already `LinkingTo: odelia`.
-- **The spike** — PR #553, the validated prototype. In this roadmap it is the
-  **specification and the regression oracle**, not the code that ships.
+- **The prototype** — plant PR #553, the validated spike. It is the **specification and
+  the regression oracle**, not the code that ships.
 
 ---
 

--- a/notes/ad-design/README.md
+++ b/notes/ad-design/README.md
@@ -1,0 +1,82 @@
+# AD infrastructure roadmap (plant × odelia)
+
+**What.** A design for computing exact **trait gradients** of the `plant` SCM's
+emergent outputs — how stand properties (LAI, biomass, basal area, offspring
+production) respond to plant traits — by **automatic differentiation (AD)**, built on
+`odelia`'s AD-aware ODE runtime rather than a plant-private AD stack.
+
+**Why.** A validated prototype exists
+([traitecoevo/plant#553](https://github.com/traitecoevo/plant/pull/553), tracking
+issue [#472](https://github.com/traitecoevo/plant/issues/472)) but rebuilt inside
+plant machinery that odelia already provides. This roadmap reaches the same gradients
+with **surgical changes** to the existing plant components and a **small generic
+surface** added to odelia — smaller, more maintainable, lower technical debt.
+
+**Status.** Design phase — no code changes yet. Branches
+`claude/ad-infrastructure-design` are prepared on the plant and odelia forks for the
+eventual implementation.
+
+---
+
+## Read in this order
+
+1. **[`ad-infrastructure-design.md`](./ad-infrastructure-design.md)** — the design.
+   The thesis, the settled decisions, the three layers (odelia / plant / UX), the
+   surgical changes, the two workflows, and the four replay levels. Start here.
+2. **[`ad-r-interface.md`](./ad-r-interface.md)** — the R/C++ boundary: why XAD types
+   are awkward through Rcpp, the "only doubles cross" invariant, and **user stories**
+   for each persona. Read after the design.
+3. **[`ad-issues.md`](./ad-issues.md)** — the work breakdown: scoped items
+   (odelia / plant / R-boundary / prototypes), dependencies, and a critical-path
+   build order. Read when planning implementation.
+
+---
+
+## Key concepts (glossary)
+
+For a reader new to the model or to AD. Fuller treatment is in the design doc.
+
+- **SCM** — the plant "Solver for Characteristics Method": integrates a size- and
+  patch-structured population as cohorts introduced on a schedule and stepped by an
+  ODE solver. The **Patch** is the state being integrated; it is already an
+  `odelia::ode::Solver` System.
+- **Emergent output / metric** — a stand-level property that emerges from the cohorts:
+  LAI, biomass, basal area, offspring production. These are the quantities we
+  differentiate.
+- **Trait gradient** — the derivative of an emergent metric with respect to plant
+  traits (lma, wood density, …). The deliverable.
+- **Two workflows.**
+  - *Resident / total* — the whole stand differentiates **with self-feedback**: a
+    trait change re-shades the canopy the stand grows in.
+  - *Mutant / invasion* — a **rare** mutant's fitness gradient against an established
+    resident whose canopy is held fixed (the mutant is too rare to shade itself).
+    This is the selection gradient of evolutionary ecology.
+- **Birth rate & demographic equilibrium** — beyond trait gradients, the derivative of
+  the net reproduction ratio with respect to birth rate (`d R0/d birth_rate`) drives the
+  Newton solve for the equilibrium birth rate (where R0 = 1) — the density at which a
+  strategy sustains itself. The birth-rate gradient is a first-class deliverable, not
+  only a sensitivity.
+- **Reverse-mode AD / XAD / tape** — reverse-mode records operations on a *tape*, then
+  sweeps it backward to get all input derivatives from one output. **XAD** is the AD
+  library odelia vendors and compiles once. Reverse mode is optimal here because there
+  are many traits (inputs) and few metrics (outputs).
+- **Replay levels (L0–L3)** — the SCM has several *adaptive* constructions (the node
+  schedule, the ODE step sizes, the light interpolator, the crown quadrature). AD
+  needs each frozen to its recorded placement so the result is differentiable. The
+  key idea (design §7.5): run once adaptively, **record where the nodes landed, replay
+  on them fixed** with the active scalar.
+- **odelia** — the family's AD-aware ODE runtime: compiles XAD once, ships a
+  scalar-templated `Solver`, a reverse-mode gradient driver, and a differentiable
+  spline. plant already `LinkingTo: odelia`.
+- **The spike** — PR #553, the validated prototype. In this roadmap it is the
+  **specification and the regression oracle**, not the code that ships.
+
+---
+
+## The one-sentence design
+
+Make the existing plant Patch and Strategy AD-compatible with small in-place changes,
+differentiate the SCM runs plant already has (`run` for resident, `run_mutant` for
+invasion) on a recorded-then-fixed replay, evaluate a plant-supplied emergent
+functional, and let odelia own the generic AD mechanism (tape, Jacobian, functional
+seam) it already almost provides — so only `double` ever crosses back to R.

--- a/notes/ad-design/ad-infrastructure-design.md
+++ b/notes/ad-design/ad-infrastructure-design.md
@@ -1,0 +1,577 @@
+# AD infrastructure design: plant emergent gradients on odelia's AD runtime
+
+**Status:** design proposal (no code changes yet).
+**Scope:** `traitecoevo/plant` (SCM emergent-trait gradients — prototype on PR
+[#553](https://github.com/traitecoevo/plant/pull/553), tracking issue
+[#472](https://github.com/traitecoevo/plant/issues/472)) and `traitecoevo/odelia`
+(the AD-aware ODE runtime).
+**Branches:** `claude/ad-infrastructure-design` on the plant and odelia forks;
+this document is on `claude/ad-infrastructure-design-87k3g8` in `plant-dev`.
+**Companions:** [`ad-issues.md`](./ad-issues.md) — tightly-scoped work items,
+dependencies, and build order; [`ad-r-interface.md`](./ad-r-interface.md) — the
+R/C++ AD boundary for both packages.
+
+---
+
+## 1. Thesis
+
+odelia is the AD runtime for this package family: it compiles XAD's `Tape` once
+and ships a scalar-templated ODE `Solver`, a persistent tape, a reverse-mode
+gradient driver, and a differentiable spline. plant already `LinkingTo: odelia`
+and already runs its SCM on `odelia::ode::Solver<patch_type>`.
+
+The #553 spike computes exact reverse-mode SCM gradients (validated to ~1e-13) but
+does so with a **second, plant-private AD stack** parallel to odelia: a third
+scalar axis, three replay engines, five hand-managed tapes, an R-side harvest, and
+reductions hand-copied from the forward model.
+
+**This design reaches the same gradients by making surgical changes to the
+existing plant components so they are AD-compatible, and by adding a small generic
+surface to odelia — not by building a parallel stack.** Two facts make this
+tractable and are the backbone of the design:
+
+- **The Patch is already the odelia System** (`Solver<patch_type>`); it needs only
+  to satisfy odelia's AD contract.
+- **`SCM::run_mutant()` is already the frozen-schedule replay** — it pins
+  integration to the resident's cached `step_history`, reads the cached
+  environment, and suppresses the mutant's self-competition. The gradient is the
+  derivative *of that existing run*, not of a new engine.
+
+The spike becomes the specification and the regression oracle.
+
+---
+
+## 2. Decisions
+
+1. **Reverse mode at the SCM level.** Emergent Jacobian is metrics × traits
+   (≈4 × 28), outputs ≪ inputs; odelia's driver is reverse-only.
+2. **Full scalar (uniform `value_type`).** The Patch/Species/Node/Individual run
+   one active scalar throughout; the spike's mixed active/frozen axis is dropped.
+   Pare back to mixed only if the §9 measurement shows the uniform tape is too
+   large.
+3. **Surgical changes to existing plant types; no new abstractions.** No
+   `SCMSystem`, no `StrategyConcept` struct. Strategy and Patch already exist; we
+   make them AD-compatible in place (§5).
+4. **odelia stays plant-agnostic.** It knows Systems, tapes, functionals, and
+   Jacobians — never cohorts, traits, emergence, or basal area. plant leads
+   odelia's API by concrete need.
+5. **Two workflows, both differentiated (issue #472).** *Resident/total* (the
+   stand differentiates with self-feedback) and *mutant/invasion* (a rare mutant
+   in the frozen resident canopy). These already exist as `run()` and
+   `run_mutant()`; the design differentiates each (§6).
+6. **Forward mode stays plant-local.** The leaf gas-exchange optimizer keeps its
+   `xad::fwd` IFT/envelope solve; odelia only *accommodates* it via an
+   analytic-adjoint edge (§4.2, §5.2).
+7. **TF24 and TF24f land in the first release**, contingent on the §8
+   cross-sensitivity prototype.
+8. **Do not merge the spike; codesign odelia first.** Second order is out of scope.
+
+---
+
+## 3. Three layers
+
+The work separates cleanly. The rest of the document is organised by these layers;
+[`ad-issues.md`](./ad-issues.md) assigns each work item to one.
+
+| Layer | Owns | Knows about plant? |
+|---|---|---|
+| **odelia** (§4) | tape, Solver, `compute_gradient`/`compute_jacobian`, the functional *shape*, the independent-variable *shape* | No |
+| **plant** (§5) | Patch-as-System, Strategy AD-compat, scalar-templated reductions, differentiating `run`/`run_mutant`, SCM orchestration | — |
+| **UX / API / workflow** (§6) | `stand_gradient()` and friends, the two workflows, the metric set, the regression oracle | — |
+
+---
+
+## 4. odelia layer (generic, plant-agnostic)
+
+### 4.1 What exists
+
+- Compiled single-definition `Tape` (`src/Tape.cpp`, `ARCHITECTURE.md`);
+  scalar-templated `Solver<System>` on `System::value_type`; Solver-owned
+  persistent tape; `compute_gradient(solver, ic, params)` (`ode_fit.hpp`); the
+  System AD contract `set_params`/`set_initial_state` returning `vector<T*>`
+  (`leaf_thermal_system.hpp`); the differentiable spline (`spline.hpp`).
+- Vendored XAD facilities: `computeJacobian` (adjoint + forward, `XAD/Jacobian.hpp`),
+  `CheckpointCallback` for analytic-adjoint injection (`XAD/CheckpointCallback.hpp`),
+  `xad::adj`/`xad::fwd` (`XAD/Interface.hpp`).
+
+### 4.2 Additions (all generic)
+
+**(a) The functional *shape*.** Today `compute_gradient` hard-codes
+`sum_of_squares` over observations. Generalize so the driver differentiates a
+caller-supplied functional of the solved system — odelia defines *"a functional
+maps a solved System to output scalar(s)"* and nothing more. `sum_of_squares` /
+`advance_target` become one prebuilt instance; plant supplies its own (§6). odelia
+never learns what the scalars mean.
+
+```cpp
+// odelia: the shape. F is any callable  std::vector<S>  f(const System& solved).
+template <class System, class F>
+std::pair<double, std::vector<double>>
+compute_gradient(Solver<System>&, const Independents&, F&& functional);
+```
+
+**(b) `compute_jacobian` (reverse, generic).** Record once, one adjoint sweep per
+output row — the adjoint variant of `XAD::computeJacobian`. Works for any odelia
+System; no plant knowledge.
+
+```cpp
+template <class System, class F>          // F -> std::vector<S> (the m outputs)
+Matrix compute_jacobian(Solver<System>&, const Independents&, F&& functional);
+// seed(independents); newRecording(); y = functional(solved);
+// registerOutputs(y);
+// for i in rows: derivative(y[i]) = 1; computeAdjoints();
+//                read derivative(input_j); clearDerivatives();
+```
+
+**(c) `Independents` — the "gradients w.r.t. what?" shape.** *(Renamed from the
+earlier `Seeds`: in AD "seed" is a verb, and in plant a "seed" is an offspring — a
+name clash. `Independents` is the standard AD term and is unambiguous.)* It is a
+generic description of which registered inputs are active and any analytic edges;
+it contains no plant vocabulary.
+
+```cpp
+struct Independents {
+  // opaque handles the System registered via set_params / set_initial_state
+  std::vector<double>       params;        // values to seed active
+  std::optional<std::vector<double>> initial_state;
+  std::vector<AnalyticEdge> edges;         // §(d)
+};
+```
+
+**(d) `AnalyticEdge` — accommodating IFT / forward-mode results.** For a value the
+forward pass computes off-tape (a root-find or optimizer result), inject its known
+partials into the reverse tape via `CheckpointCallback::computeAdjoint`. This is
+odelia's compatibility seam for plant's leaf-optimizer forward-mode sensitivity and
+the TF24 stomatal IFT — generic (odelia sees inputs, an output, and partials), and
+it replaces the spike's hand-rolled `inject_h0`.
+
+---
+
+## 5. plant layer (surgical changes to existing components)
+
+Each change below is a small in-place modification of a type that already exists.
+
+### 5.1 Patch — satisfy odelia's System AD contract
+
+The Patch is already the System (`SCM` holds `odelia::ode::Solver<patch_type>`).
+Changes:
+
+- **Uniform `value_type = S`**, replacing the spike's mixed
+  physiology-active/demography-double split (decision 2). Prefer **not** to thread a
+  third template parameter: let the strategy and environment carry the scalar
+  (`T = FF16_Strategy<S>`, `E = FF16_Environment<S>`) and have `Individual`/`Node`/
+  `Species`/`Patch` derive `using value_type = typename T::value_type`. That collapses
+  the spike's `<T,E,S>` to the existing `<T,E>` and matches odelia's `value_type`
+  convention — fewer signatures to touch, and the scalar lives with the types that
+  own the parameters.
+- **Add `set_params(tape, it)` / `set_initial_state(tape, it, t0)`** returning the
+  registered active inputs — the same contract `leaf_thermal_system.hpp` models.
+  This is where traits and birth-rate become active; the map from trait names to
+  registered fields is plant's (§5.2).
+
+These are methods on the existing Patch, not a new wrapper type.
+
+### 5.2 Strategy — make traits seedable, keep physiology scalar-templated
+
+The Strategy classes already exist and already expose per-method `template<class S>`
+physiology (`area_leaf<S>`, `update_dependent_aux<S>`). Two minimal changes:
+
+- **One parameter representation that can be active.** Today the strategy stores
+  double `pars` and the replay carries a *separate* lifted active struct
+  (`TF24ProdPars<AD> p; p.lma = pd.lma; …`). Collapse to a single scalar-templated
+  parameter store so a named trait can be registered active directly (feeding
+  §5.1's `set_params`). This removes the dual representation.
+- **Leaf-optimizer edge.** TF24/TF24f keep their forward-mode leaf solve; expose
+  its sensitivity as an `AnalyticEdge` (§4.2d) rather than the spike's active-`h0`
+  injection.
+
+The existing FF16 (no optimizer) needs only the parameter-store change.
+
+### 5.3 Reductions — scalar-template the model's own quadratures, delete the copies
+
+`Species::compute_competition(double height)` **is** the census/light trapezium
+that the gradient layer copies as `canopy_comp_at`; it currently returns `double`.
+Surgical change: **template it (and the patch census integral) on `S`** so the same
+function serves the forward model (`S=double`, unchanged) and the gradient replay
+(`S=active`). Then `inst/include/plant/gradient/{coupled_canopy.h, scm_harvest.h}`
+retire and exactness is structural, not a maintained bit-for-bit copy.
+
+### 5.4 The replay is `run_mutant` / `run`, differentiated — not a new engine
+
+The two workflows differentiate two existing runs, and they differ precisely in how
+the canopy (L3, §7) is accessed:
+
+- **Invasion** = differentiate `SCM::run_mutant(p)` with `S=active`. It switches the
+  Patch to the cached resident environment (`set_mutant()`), pins the schedule to
+  the resident `step_history` (`use_ode_times`), and runs — the mutant reads the
+  **frozen** canopy and does not compete with itself (`is_mutant_run` gates
+  `compute_competition`). The derivative through the canopy is zero.
+- **Resident / total** = differentiate the resident run on the *same* frozen L0/L1
+  schedule, but with the canopy **reconstructed from the active cohorts** (§7, L3
+  reconstructed) so a trait re-shades the stand. It must **not** read the frozen
+  `environment_history` — doing so collapses it to the invasion gradient.
+
+Either way the three `*_emergent.cpp` engines are replaced by *differentiating the
+SCM we already have*, not a new engine. The resident canopy is re-computed live by
+re-running `compute_environment` on recorded fixed knots (§7.5) — not reconstructed
+from a stand-state cache — so `stand_stage_history` and its variants are retired.
+
+The spike's paired `*_impl` (R-list) / `*_native` (live-Patch) entry points are a
+migration scaffold — `_impl` was kept only as a finite-difference reference while the
+native path was proven. The design carries only the native path; the `_impl` half is
+not first-class and is dropped once the regression oracle (UX-2) replaces it.
+
+### 5.5 SCM orchestration over odelia's atomic components
+
+The SCM stays the plant-specific orchestrator; odelia supplies the atoms
+(`advance_fixed`/`advance_adaptive`, tape). Two orchestration points matter for AD:
+
+- **Node introductions grow the system; they are not discontinuities.**
+  `run_next_impl` introduces cohorts at scheduled times, then integrates to the
+  next event. When the node schedule is frozen (§7, L0) the introduction times are
+  *constants* (`d(t_intro)/d(trait) = 0`), so introductions add tape variables (a
+  wider state) but inject no discontinuity into the differentiated output. This is
+  exactly why the schedule must be frozen: an adaptive, trait-dependent schedule
+  *would* be non-differentiable. One recording spans the whole run across
+  introductions.
+- **Adaptivity is frozen in layers, not all at once.** The SCM has *four* adaptive
+  constructions that each break differentiability, and they are frozen
+  independently at different depths (the node schedule, the ODE step times, the
+  quadrature/interpolator knots, and — for invasion — the resident environment).
+  These are the "replay levels" of §7, which sets out which levels each gradient
+  needs.
+
+---
+
+## 6. UX / API / workflow layer
+
+### 6.1 The two workflows (issue #472)
+
+| Workflow | SCM entry | Environment | Gradient meaning |
+|---|---|---|---|
+| **Resident / total** | `run()` | co-moving (stand re-shades itself) | d(emergent metric)/d(trait), full self-feedback |
+| **Mutant / invasion** | `run_mutant()` | frozen resident canopy | selection gradient: d(rare-mutant fitness)/d(mutant trait) |
+
+The mutant has low density in an established stand: it competes with the residents
+but not with itself, so its fitness gradient holds the environment fixed. Positive
+fitness ⇒ it can invade. This is a genuinely separate workflow, not a mode flag on
+the first — and both are pre-existing SCM capabilities the design differentiates.
+
+### 6.2 Gradient semantics
+
+| Gradient | Workflow | Cross term | Notes |
+|---|---|---|---|
+| Trait, invasion | mutant | 0 (frozen canopy) | the selection gradient; `offspring_production` is always this |
+| Trait, resident | resident | present | species re-shades the stand it lives in |
+| Birth-rate, census metric | resident | present | the frozen part is the trivial identity `metric / birth_rate`; only the resident (canopy-feedback) axis needs a tape — and it is non-trivial, e.g. it **flips the sign of biomass** vs. the identity |
+| Birth-rate, `d R0/d birth_rate` | mutant framing | — | `d(net_reproduction_ratio)/d(birth_rate)`; the density-feedback axis |
+
+**A key application: the demographic-equilibrium solve.** `d R0/d birth_rate` is the
+plant-side derivative for the Newton solve that finds the equilibrium birth rate
+(R0 = 1) — the resident density at which a strategy sustains itself. It is computed on
+the same coupled replay via the mutant framing (mutant traits = resident; the change
+in mutant fitness as resident density moves is the density feedback). This makes the
+birth-rate gradient not just a sensitivity but the enabling piece for equilibrium and
+invasion analyses — worth first-class support even though the trait gradients are the
+headline.
+
+The resident-vs-frozen distinction is therefore not a minor correction anywhere: the
+canopy feedback can dominate and reverse the sign of a response (biomass under
+birth-rate is the worked example). "Which feedback" is a real modelling choice, not a
+tolerance detail.
+
+### 6.3 Public API (unchanged surface)
+
+`stand_gradient(scm, metrics, traits, species, feedback=…)` keeps its shape and maps
+to `compute_jacobian(solver, independents(traits, species, birth_rate),
+EmergentFunctional{metrics})`, where `EmergentFunctional` is plant-supplied and
+reuses §5.3's reductions. The R harvest and `Rcpp::as<>` round-trip disappear (the
+functional reads native state on the tape). Adding a metric is a one-kernel change
+in plant that reuses model functions; odelia is untouched.
+
+---
+
+### 6.4 What each workflow accesses: two orthogonal axes
+
+A workflow is a choice on **two independent axes**, and separating them removes most
+of the apparent complexity:
+
+- **Replay** — which adaptive constructions must be recorded and replayed fixed
+  (§7). This is a property of the *system*, not the question: the plant SCM always
+  needs L0·L1·L2; a bare ODE (odelia's Lorenz) needs only L1. Plus the ecological
+  choice of **feedback** — resident (canopy re-run, active) vs. invasion (canopy
+  frozen), which is L3.
+- **Functional** — what scalar is differentiated: an **emergent metric** (no
+  observations) or a **likelihood over observations** (§4.2a). Orthogonal to replay.
+
+The workflows are just points in that grid:
+
+| Priority | Workflow | Replay (system) | Feedback | Functional |
+|---|---|---|---|---|
+| **1 (primary)** | Emergent gradient, resident (forest ecologist) | SCM: L0·L1·L2 | resident (re-run) | emergent metric |
+| **2** | Mutant/invasion fitness (evolutionary ecologist) | SCM: L0·L1·L2 | invasion (frozen) | emergent metric |
+| **3 (advanced)** | Calibration / inference | *same replay as the system needs* | resident | **likelihood over observations** |
+
+**Calibration is not a different replay — it is a different functional.** Calibrating
+the plant SCM to data uses the *same* resident replay as workflow 1 (L0·L1·L2) with a
+likelihood functional layered on top: an **addition, not a subtraction**. It looks
+simpler in odelia only because Lorenz is a bare ODE (L1) with no canopy — the ODE-fit
+example is the degenerate case, and its `set_target`/`fit` shape must **not** set the
+plant UX. The emergent workflows (1, 2) are primary because they need no observations;
+calibration is advanced because it additionally requires the user to define targets
+and a likelihood.
+
+## 7. Replay levels: four independent freezes
+
+"Differentiate the converged construction" applies at four *distinct* depths in the
+SCM. Each freezes a different adaptive construction that would otherwise break
+differentiability; they compose, and a given gradient needs only some of them.
+Treating them as one "frozen schedule" hides which a given gradient needs, so they are
+kept distinct here.
+
+| Level | Freezes | Captured by | Removes non-diff from | Owner |
+|---|---|---|---|---|
+| **L0 — node schedule** | which cohorts exist and when introduced | `build_schedule`/`refine_schedule`, *before* the adaptive run | adaptive cohort introduction | plant |
+| **L1 — ODE step times** | the adaptive RKCK step selection | `solver.times()` → `advance_target`/`advance_fixed` (pinned replay) | adaptive step-size control | **odelia (exists)** |
+| **L2 — quadrature / interpolator knots** | height-QAG abscissae and the light-spline knots | cached knots (frozen) *or* scalar-templated `QK` (moving nodes) | adaptive quadrature / interpolation refinement | plant (`qk.h`) + odelia spline |
+| **L3 — resident canopy** | the resident environment the focal cohorts read | `save_RK45_cache` (stores *both* frozen env values *and* resident stand state) | see below — **frozen ≠ reconstructed** | plant |
+
+**L1 is the ODE-fit case (calibration), and it already works — but it is not the
+plant driver (§6, R-interface).** odelia's own AD test (`test-ad-workflow.R`) runs a
+Lorenz solve adaptively, captures `times()`, and replays pinned via
+`set_target`/`advance_target` — *no environment cache, just the resolved ODE
+schedule*. It needs L1 alone.
+
+**L2 has two variants, and #472 flags the harder one.** For the resident light
+spline, the knots are frozen (positions) and the values active — odelia's
+differentiable spline (§4.1). For a census integrated over height, the integration
+bound *is* an active plant height, so the Gauss–Kronrod **nodes move**: this needs
+the scalar-templated `QK` (`qk.h`, already written for #472) rather than a
+frozen-node replay, which "would miss" the moving-node sensitivity.
+
+**L3 is accessed two *different* ways — and this is the correctness crux.** The
+resident run records the frozen resident environment *values* (`environment_history`)
+and the light-spline knot *positions* (§7.5); the two gradients diverge on which they
+use. (The spike additionally caches full stand state per RK stage,
+`stand_*_stage_history`; §7.5 shows that is unnecessary — record knots, re-run the
+canopy.)
+
+- **Invasion (frozen):** a rare mutant reads the cached `environment_history` as a
+  **constant** — the derivative through the canopy is zero by construction. This is
+  `run_mutant` (`is_mutant_run` suppresses self-competition). Correct for a rare
+  invader.
+- **Resident / total (re-run):** the canopy is **recomputed live** by re-running
+  `compute_environment` on the *recorded* light-spline knots (§7.5) with the active,
+  re-evolved cohorts, so a trait re-shades the stand through `area_leaf`.
+  **Replaying the frozen environment here would silently give the invasion gradient —
+  the self-shading cross term would be missing.** The resident total gradient
+  therefore does *not* read the frozen env; it re-runs the model's own light on fixed
+  knots. (No `stand_stage_history` — §7.5.)
+
+### Which workflow needs which levels
+
+The replay levels are a property of the **system**, not the workflow: any gradient of
+the plant SCM needs L0·L1·L2; a bare ODE needs only L1. Feedback (L3) and the
+functional are the orthogonal choices (§6.4).
+
+| Gradient | L0 | L1 | L2 | L3 |
+|---|:--:|:--:|:--:|:--:|
+| Bare-ODE fit (odelia Lorenz — the degenerate case) | | ✅ | | |
+| Offspring, invasion | ✅ | ✅ | | frozen |
+| Census (LAI/biomass/basal area), resident | ✅ | ✅ | ✅ | **re-run** |
+| Census, invasion | ✅ | ✅ | ✅ | frozen |
+| SCM calibration to data | ✅ | ✅ | ✅ | re-run |
+
+The last two rows share the L0·L1·L2·L3-re-run replay; they differ only in the
+functional (emergent metric vs. likelihood) — the point of §6.4.
+
+### The fixed comb still makes functionals simple
+
+With L0–L1 frozen, the emergent functionals are simple reductions over a fixed set
+of cohorts. Offspring is a **constant-weighted sum** `Σ tw_i · offspring_i` (fixed
+introduction times ⇒ constant weights). A census reduction is
+`Species::compute_competition` scalar-templated (§5.3) — reused, not re-derived —
+with L2 supplying the (moving or frozen) quadrature nodes. The design keeps the
+*same* quadratures the model already uses and differentiates them; it adds no new
+integration.
+
+---
+
+### 7.5 One primitive under every level: record the adaptive nodes, replay fixed
+
+The four levels look like four mechanisms but are one idea. Every adaptive numerical
+construction in the SCM — the RKCK stepper, the light interpolator
+(`AdaptiveInterpolator` refining knots over height every step), the crown-depth
+quadrature (`qag.h`) — exists to *discover* where to place nodes to hit an error
+tolerance **without knowing the answer**. On a replay we already know the answer, so
+adaptivity is pure overhead: record where the first (double, adaptive) pass placed
+its nodes, then replay on those nodes held fixed, with the scalar active. No
+refinement loop runs on the AD pass.
+
+| Adaptive construction | Records | Replays as | Status |
+|---|---|---|---|
+| RKCK stepper | step times (`solver.times()`) | `advance_fixed` | odelia — exists |
+| light interpolator | knot positions (`AdaptiveInterpolator` → `get_x()`) | `basic_interpolator<S>`, frozen x + active y | odelia primitive exists |
+| crown-depth quadrature | QAG subdivision (or none — a fixed rule) | scalar-templated `QK<S>` on fixed abscissae | `qk.h` exists; recording is the one gap |
+
+`basic_interpolator<S>` is the interpolator instance of this: the ordinary
+interpolator with the value scalar templated, so a frozen set of recorded knots
+carries active values differentiably (via `basic_spline<S>`). The stepper
+(`advance_fixed`) and the quadrature (fixed `QK<S>`) are the same shape — record
+positions on the adaptive pass, replay values on the fixed positions.
+
+**This eliminates `stand_stage_history`.** The spike caches the resident stand state
+per RK stage so it can *reconstruct* the light without re-running
+`compute_environment`. But if the replay simply **re-runs the model's own
+`compute_environment` on the recorded knots with the active, re-evolved cohorts**,
+the light is recomputed live and responds to traits — no stand-state cache. What must
+be recorded per step is only the **knot positions** (a short vector of heights); the
+cohort values come from the replay itself. The heavy `stand_*_stage_history` /
+`stand_newnode_*` / all-species caches in `patch.h` are not needed under the
+full-scalar re-run.
+
+**The resident and calibration workflows share one replay.** Both are "run adaptive
+once, record the nodes, replay fixed with the active scalar." They differ in only two
+things:
+
+1. the **functional** — an emergent metric (no observations) vs. a likelihood over
+   observations; and
+2. **how many adaptive constructions are in replay mode** — calibration replays only
+   the ODE stepper (L1); the emergent resident gradient also replays the light
+   interpolator and crown quadrature (L2).
+
+The resident canopy is live-active (self-shading) simply because `compute_environment`
+re-runs on active cohorts; the invasion gradient reuses the *recorded double* light
+spline unchanged (frozen). One record-then-replay-fixed primitive, applied at whichever
+levels a gradient needs.
+
+**Boundary of applicability (measured on the spike).** Fixed-node replay assumes the
+recorded nodes stay adequate when the scalar goes active. This holds for FF16 (bounded,
+closed-form light response) and for TF24/TF24f at moderate horizons. It **fails for the
+TF24f resident coupled feedback at long patch lifetimes**: the `log_density`↔canopy loop
+is stiff (a deeply-shaded cohort carries a large leaf `dprofit/dL`), and the live SCM
+tames it with *adaptive* sub-stepping that a fixed schedule cannot reproduce — the double
+frozen-step replay itself drifts (env err ~1e-6 at H4 → ~2e-2 at H5+). The true gradient
+exists (full-SCM finite differences are finite); only the fixed replay diverges. So the
+primitive is the right default, but stiff coupled horizons need **adaptive sub-stepping in
+the replay** (future hardening, §11) — not a universal guarantee. (This is a milder
+relative of the #550 density blow-up: same size-density equation, but a replay artifact
+rather than a genuine caustic.)
+
+### 7.6 Mechanism and abstraction
+
+Two complementary mechanisms implement §7.5, and both already exist in odelia in part.
+
+**Recording is an opt-in System hook, detected at compile time.** odelia's stepper
+already does exactly this for the RK45 cache: a trait (`has_cache` detecting
+`cache_RK45_step`) makes the generic stepper call `system.cache_RK45_step()` per RK
+stage and `system.cache_ode_step()` per step, compiling to a **zero-cost no-op** for
+systems that don't provide the hook (`ode_interface.hpp`, `ode_step.hpp:77`,
+`ode_solver_internal.hpp:83`). odelia never learns what is cached. The record side of
+§7.5 reuses these hook points; the simplification is mostly **shrinking what plant
+records through them** (knot positions, not `stand_stage_history`).
+
+Recommendation: keep the opt-in-hook design (the system opts in; odelia stays
+agnostic; an absent hook compiles away), but express new hooks with **C++20 concepts +
+`if constexpr`** rather than more `enable_if` SFINAE. The project is already
+`CXX_STD = CXX20`, and a `requires`-based `Recordable` concept reads far better than
+`std::enable_if<has_cache<System>::value>` for a developer meeting the code for the
+first time (optionally retrofitting the existing traits for consistency).
+
+**Replay-fixed is a component mode, expressed by scalar-templating over frozen
+nodes.** The abstraction is one idea reused three times, and it is minimal:
+
+- `basic_spline<S>` — the ttk592 spline templated on the *value* scalar (knot
+  positions stay `double`); this is the interpolation math itself.
+- `basic_interpolator<S>` — a thin usage layer over it (domain, extrapolation, eval,
+  the R seam). The two-layer split (math vs. usage) is worth keeping.
+- `QK<S>` — the fixed Gauss–Kronrod rule with the integrand scalar templated and the
+  abscissae `double`; `advance_fixed` is the stepper instance.
+
+"Freeze the nodes, template the value/integrand scalar" is the smallest construct that
+makes a fixed-node numeric differentiable, and it is already proven for the
+interpolator. Extending it to `QK<S>` is endorsed; `QK<S>` can be a single
+scalar-templated primitive — it need not mirror the spline/interpolator two-layer
+split, which keeps the odelia numerics surface small.
+
+## 8. Strategy coverage and the cross-sensitivity gap
+
+| Strategy | Offspring | Census, invasion | Census, resident | Blocker |
+|---|---|---|---|---|
+| FF16 | ✅ | ✅ | ✅ | — (no leaf optimizer) |
+| TF24f | ✅ | ✅ (long-horizon gate) | partial | stiff feedback at long lifetime |
+| TF24 | ✅ | ✗ in spike | ✗ in spike | **leaf-optimizer cross-sensitivity** |
+
+**The gap:** TF24/TF24f solve a per-cohort leaf optimum; a census metric depends on
+it, so a trait shift moves the optimum → growth → census density. The spike's
+*linearised, frozen* harvest injects the leaf sensitivity along the focal path but
+zeroes this cross-term through the density.
+
+**Why the full-scalar design plausibly closes it:** with the whole `run_mutant`
+replay on one tape and the leaf IFT delivered as an `AnalyticEdge` (§4.2d) rather
+than a frozen-path injection, the reverse sweep traverses density→optimum→trait
+natively. **This is the single highest-risk claim; the §-prototype in `ad-issues.md`
+(PROTO-2) must confirm it** before TF24 census is guaranteed for v1 (decision 7).
+
+---
+
+## 9. Scalar-cost measurement (validates decision 2)
+
+Before building the production path: implement the FF16 frozen cohort as a
+uniform-`value_type` System, gradient one metric, and compare `tape.getMemory()` /
+wall-clock against the spike's mixed engine (`scripts/bench_gradient.R`). Outcomes:
+(a) within a small constant → ship uniform scalar; (b) decisively worse → keep a
+mixed scalar but as an odelia "frozen input" concept (inputs with a permanent zero
+adjoint), not a hand-threaded template axis; (c) ambiguous → uniform for
+maintainability. This is PROTO-1.
+
+---
+
+## 10. Migration (spike as oracle)
+
+Snapshot the spike's validated Jacobians to a regression fixture and assert
+bit-identity (relocations) or a documented noise floor (FP-reorder paths) at every
+step, plus the existing AD-vs-FD physics tests. Build order and dependencies are in
+[`ad-issues.md`](./ad-issues.md); in brief: odelia foundation (functional shape,
+`compute_jacobian`, `Independents`/`AnalyticEdge`) → scalar-cost spike → FF16
+invasion via differentiated `run_mutant` → FF16 resident + spline → TF24/TF24f (+
+cross-sensitivity prototype) → delete the engines, R harvest, and local tapes.
+
+---
+
+## 11. Risks and open areas
+
+- **TF24 census cross-sensitivity (§8)** — highest risk; gated on PROTO-2.
+- **Scalar cost (§9)** — default unproven; gated on PROTO-1.
+- **`AnalyticEdge`/`CheckpointCallback` ergonomics (§4.2d, §5.2)** — mechanism
+  exists but is unused in plant; needs PROTO-3 to fix its API.
+- **Metric set (§6.3)** — enumerate the required metrics + kernels so the interface
+  covers them in one shape.
+- **Resident TF24f at long horizon (§7.5, §8)** — the fixed-step replay cannot tame the
+  stiff `log_density`↔canopy feedback that the adaptive SCM does. True horizon extension
+  needs adaptive sub-stepping in the replay; likely stays gated in v1 (clear error, not a
+  wrong number), with the gate driven by the double replay's env error.
+- **Boundary / zero-height cohort trap (correctness).** A cohort introduced on the final
+  step (`birth == N`) can sit at zero height, where `area_leaf = (h/a_l1)^(1/a_l2)`
+  differentiates to `0·log(0) = NaN` (it also biased the *value*). The spike fixes this by
+  establishing `birth ≥ N` cohorts at the seed height `h0`; the port must carry that fix.
+  A known, concrete AD trap — worth an explicit test.
+
+---
+
+## Appendix: source references
+
+**odelia** — `inst/include/XAD/{Jacobian,CheckpointCallback,Interface}.hpp`;
+`inst/include/odelia/{ode_fit,ode_solver,spline,interpolator}.hpp`;
+`inst/examples/leaf_thermal/src/leaf_thermal_system.hpp`; `ARCHITECTURE.md`.
+
+**plant** — `inst/include/plant/scm.h` (`run`, `run_next_impl`, `run_mutant`,
+`Solver<patch_type>`); `inst/include/plant/patch.h` (`set_mutant`,
+`introduce_new_nodes`, `environment_history`/`step_history`, `is_mutant_run`);
+`inst/include/plant/species.h` (`compute_competition` — the census trapezium, still
+`double`); `inst/include/plant/models/ff16_strategy.h` (`template<class S>`
+physiology; double `pars`); `src/{ff16,tf24,tf24f}_emergent.cpp` (the parallel
+engines, five local tapes, `inject_h0`); `src/leaf_model.cpp`,
+`src/tf24_strategy.cpp` (forward-mode leaf IFT); `R/*_emergent_gradient.R` (harvest,
+round-trip, `frozen`/`resident` feedback); `inst/include/plant/gradient/*` (the
+reduction copies to retire); `notes/ad-refactor-optimize-roadmap.md`.

--- a/notes/ad-design/ad-infrastructure-design.md
+++ b/notes/ad-design/ad-infrastructure-design.md
@@ -1,149 +1,126 @@
 # AD infrastructure design: plant emergent gradients on odelia's AD runtime
 
-**Status:** design proposal (no code changes yet).
-**Scope:** `traitecoevo/plant` (SCM emergent-trait gradients — prototype on PR
+**Scope:** `traitecoevo/plant` (SCM emergent-trait gradients) on `traitecoevo/odelia`
+(the AD-aware ODE runtime). A validated prototype — plant PR
 [#553](https://github.com/traitecoevo/plant/pull/553), tracking issue
-[#472](https://github.com/traitecoevo/plant/issues/472)) and `traitecoevo/odelia`
-(the AD-aware ODE runtime).
-**Branches:** `claude/ad-infrastructure-design` on the plant and odelia forks;
-this document is on `claude/ad-infrastructure-design-87k3g8` in `plant-dev`.
-**Companions:** [`ad-issues.md`](./ad-issues.md) — tightly-scoped work items,
-dependencies, and build order; [`ad-r-interface.md`](./ad-r-interface.md) — the
-R/C++ AD boundary for both packages.
+[#472](https://github.com/traitecoevo/plant/issues/472) — is the specification and the
+regression oracle.
+**Companions:** [`ad-record-replay.md`](./ad-record-replay.md) — the record→replay
+primitive beneath the replay levels (§7); [`ad-r-interface.md`](./ad-r-interface.md) —
+the R/C++ AD boundary for both packages.
 
 ---
 
 ## 1. Thesis
 
-odelia is the AD runtime for this package family: it compiles XAD's `Tape` once
-and ships a scalar-templated ODE `Solver`, a persistent tape, a reverse-mode
-gradient driver, and a differentiable spline. plant already `LinkingTo: odelia`
-and already runs its SCM on `odelia::ode::Solver<patch_type>`.
+odelia is the AD runtime for this package family: it compiles XAD's `Tape` once and
+ships a scalar-templated ODE `Solver`, a persistent tape, a reverse-mode gradient
+driver, and a differentiable spline. plant already `LinkingTo: odelia` and runs its SCM
+on `odelia::ode::Solver<patch_type>`.
 
-The #553 spike computes exact reverse-mode SCM gradients (validated to ~1e-13) but
-does so with a **second, plant-private AD stack** parallel to odelia: a third
-scalar axis, three replay engines, five hand-managed tapes, an R-side harvest, and
-reductions hand-copied from the forward model.
+Exact reverse-mode SCM gradients therefore follow from **surgical changes to the plant
+components that already exist**, plus a **small generic surface on odelia** — not a
+second, plant-private AD stack. Two facts carry the design:
 
-**This design reaches the same gradients by making surgical changes to the
-existing plant components so they are AD-compatible, and by adding a small generic
-surface to odelia — not by building a parallel stack.** Two facts make this
-tractable and are the backbone of the design:
-
-- **The Patch is already the odelia System** (`Solver<patch_type>`); it needs only
-  to satisfy odelia's AD contract.
-- **`SCM::run_mutant()` is already the frozen-schedule replay** — it pins
-  integration to the resident's cached `step_history`, reads the cached
-  environment, and suppresses the mutant's self-competition. The gradient is the
-  derivative *of that existing run*, not of a new engine.
-
-The spike becomes the specification and the regression oracle.
+- **The Patch is already the odelia System** (`Solver<patch_type>`); it needs only to
+  satisfy odelia's AD contract.
+- **`SCM::run_mutant()` is already the frozen-schedule replay** — it pins integration to
+  the resident's cached `step_history`, reads the cached environment, and suppresses the
+  mutant's self-competition. The invasion gradient is the derivative *of that existing
+  run*, not of a new engine.
 
 ---
 
 ## 2. Decisions
 
-1. **Reverse mode at the SCM level.** Emergent Jacobian is metrics × traits
-   (≈4 × 28), outputs ≪ inputs; odelia's driver is reverse-only.
-2. **Full scalar (uniform `value_type`).** The Patch/Species/Node/Individual run
-   one active scalar throughout; the spike's mixed active/frozen axis is dropped.
-   Pare back to mixed only if the §9 measurement shows the uniform tape is too
-   large.
-3. **Surgical changes to existing plant types; no new abstractions.** No
-   `SCMSystem`, no `StrategyConcept` struct. Strategy and Patch already exist; we
-   make them AD-compatible in place (§5).
-4. **odelia stays plant-agnostic.** It knows Systems, tapes, functionals, and
-   Jacobians — never cohorts, traits, emergence, or basal area. plant leads
-   odelia's API by concrete need.
-5. **Two workflows, both differentiated (issue #472).** *Resident/total* (the
-   stand differentiates with self-feedback) and *mutant/invasion* (a rare mutant
-   in the frozen resident canopy). These already exist as `run()` and
-   `run_mutant()`; the design differentiates each (§6).
+1. **Reverse mode at the SCM level.** The emergent Jacobian is metrics × traits
+   (≈4 × 28) — outputs ≪ inputs — so the reverse (adjoint) driver is optimal.
+2. **One uniform `value_type = S`.** Patch/Species/Node/Individual run a single active
+   scalar throughout; there is no separate active/frozen physiology axis. The scalar
+   lives with the types that own the parameters, so `<T,E,S>` collapses to the existing
+   `<T,E>` (§5.1).
+3. **Surgical changes to existing types; no new abstractions.** No `SCMSystem`, no
+   `StrategyConcept`. Strategy and Patch already exist and are made AD-compatible in
+   place (§5).
+4. **odelia stays plant-agnostic.** It knows Systems, tapes, functionals, and Jacobians
+   — never cohorts, traits, emergence, or basal area. plant leads odelia's API by
+   concrete need.
+5. **Two workflows, both differentiated.** *Resident/total* (the stand differentiates
+   with self-feedback) and *mutant/invasion* (a rare mutant in the frozen resident
+   canopy) already exist as `run()` and `run_mutant()`; the design differentiates each
+   (§6).
 6. **Forward mode stays plant-local.** The leaf gas-exchange optimizer keeps its
-   `xad::fwd` IFT/envelope solve; odelia only *accommodates* it via an
-   analytic-adjoint edge (§4.2, §5.2).
-7. **TF24 and TF24f land in the first release**, contingent on the §8
-   cross-sensitivity prototype.
-8. **Do not merge the spike; codesign odelia first.** Second order is out of scope.
+   `xad::fwd` IFT solve; odelia accommodates it through a supplied-derivative edge
+   (§4, §5.2), not by absorbing it.
 
 ---
 
 ## 3. Three layers
 
-The work separates cleanly. The rest of the document is organised by these layers;
-[`ad-issues.md`](./ad-issues.md) assigns each work item to one.
+The work separates cleanly, and the document is organised by these layers.
 
 | Layer | Owns | Knows about plant? |
 |---|---|---|
-| **odelia** (§4) | tape, Solver, `compute_gradient`/`compute_jacobian`, the functional *shape*, the independent-variable *shape* | No |
+| **odelia** (§4) | tape, Solver, `compute_gradient`/`compute_jacobian`, the functional *shape*, the differentiation-target *shape* | No |
 | **plant** (§5) | Patch-as-System, Strategy AD-compat, scalar-templated reductions, differentiating `run`/`run_mutant`, SCM orchestration | — |
-| **UX / API / workflow** (§6) | `stand_gradient()` and friends, the two workflows, the metric set, the regression oracle | — |
+| **UX / API / workflow** (§6) | `stand_gradient()` and friends, the two workflows, the metric set | — |
 
 ---
 
 ## 4. odelia layer (generic, plant-agnostic)
 
-### 4.1 What exists
+odelia supplies the compiled single-definition `Tape`, a scalar-templated
+`Solver<System>` on `System::value_type` with a Solver-owned persistent tape, the
+`set_params`/`set_initial_state` System contract with the `rebind` lift and `scatter`
+routing, and the differentiable spline — over the vendored XAD facilities
+(`computeJacobian`, `CheckpointCallback`, `xad::adj`/`xad::fwd`). The generic AD surface
+above them is four pieces.
 
-- Compiled single-definition `Tape` (`src/Tape.cpp`, `ARCHITECTURE.md`);
-  scalar-templated `Solver<System>` on `System::value_type`; Solver-owned
-  persistent tape; `compute_gradient(solver, ic, params)` (`ode_fit.hpp`); the
-  System AD contract `set_params`/`set_initial_state` returning `vector<T*>`
-  (`leaf_thermal_system.hpp`); the differentiable spline (`spline.hpp`).
-- Vendored XAD facilities: `computeJacobian` (adjoint + forward, `XAD/Jacobian.hpp`),
-  `CheckpointCallback` for analytic-adjoint injection (`XAD/CheckpointCallback.hpp`),
-  `xad::adj`/`xad::fwd` (`XAD/Interface.hpp`).
-
-### 4.2 Additions (all generic)
-
-**(a) The functional *shape*.** Today `compute_gradient` hard-codes
-`sum_of_squares` over observations. Generalize so the driver differentiates a
-caller-supplied functional of the solved system — odelia defines *"a functional
-maps a solved System to output scalar(s)"* and nothing more. `sum_of_squares` /
-`advance_target` become one prebuilt instance; plant supplies its own (§6). odelia
-never learns what the scalars mean.
+**(a) The functional shape.** A functional maps a replayed System to output scalar(s),
+and nothing more. It is a **pure reduction**: it reads state and returns a scalar; it
+does not drive the solver and carries no schedule. The driver owns the replay on the
+recorded schedule (`advance_fixed(recorded_steps())`) and the Solver stores no fit
+state. The calibration loss is one prebuilt instance, `least_squares`, holding only its
+measured observations and which recorded steps they attach to; plant supplies its own
+emergent functional (§6). odelia never learns what the scalars mean.
 
 ```cpp
-// odelia: the shape. F is any callable  std::vector<S>  f(const System& solved).
+// F is any callable  std::vector<S>  f(const System& replayed).
 template <class System, class F>
 std::pair<double, std::vector<double>>
-compute_gradient(Solver<System>&, const Independents&, F&& functional);
+compute_gradient(Solver<System>&, const DifferentiationTargets&, F&& functional);
 ```
 
-**(b) `compute_jacobian` (reverse, generic).** Record once, one adjoint sweep per
-output row — the adjoint variant of `XAD::computeJacobian`. Works for any odelia
-System; no plant knowledge.
+**(b) `compute_jacobian` (reverse, generic).** Record once, one adjoint sweep per output
+row — the adjoint variant of `XAD::computeJacobian`, over any odelia System, with no
+plant knowledge. Two properties are load-bearing:
 
-```cpp
-template <class System, class F>          // F -> std::vector<S> (the m outputs)
-Matrix compute_jacobian(Solver<System>&, const Independents&, F&& functional);
-// seed(independents); newRecording(); y = functional(solved);
-// registerOutputs(y);
-// for i in rows: derivative(y[i]) = 1; computeAdjoints();
-//                read derivative(input_j); clearDerivatives();
-```
+- **Pass the codomain** (output count) to `computeJacobian`. Omitting it costs an extra
+  forward evaluation — a full solve, i.e. a full SCM replay for plant — just to size the
+  outputs. The functional knows its output arity, so it supplies it.
+- **Column order is a contract.** Output column `j` is `d(output)/d(leaf_j)` for the
+  `j`-th seeded leaf *in the order the System consumes them*. A caller resolving trait
+  names → fields must pack and scatter in the same order, or the columns transpose
+  silently.
 
-**(c) `Independents` — the "gradients w.r.t. what?" shape.** *(Renamed from the
-earlier `Seeds`: in AD "seed" is a verb, and in plant a "seed" is an offspring — a
-name clash. `Independents` is the standard AD term and is unambiguous.)* It is a
-generic description of which registered inputs are active and any analytic edges;
-it contains no plant vocabulary.
+**(c) `DifferentiationTargets` — the "gradients w.r.t. what?" shape.** A generic
+description of which registered inputs are active, with no plant vocabulary: a set of
+addressed leaves the System routes to its own fields. A trait-seed and an
+initial-condition-seed are the same kind of thing — a registered leaf — and IC
+sensitivity is a genuine target (plant's `make_initial_state` / `export_patch_state`
+make an initial size distribution a first-class input). So the shape carries no
+privileged `params` / `initial_state` split: any subset — traits, ICs, or both — is
+expressible, and the System owns the routing. odelia never learns what a leaf means.
 
-```cpp
-struct Independents {
-  // opaque handles the System registered via set_params / set_initial_state
-  std::vector<double>       params;        // values to seed active
-  std::optional<std::vector<double>> initial_state;
-  std::vector<AnalyticEdge> edges;         // §(d)
-};
-```
-
-**(d) `AnalyticEdge` — accommodating IFT / forward-mode results.** For a value the
-forward pass computes off-tape (a root-find or optimizer result), inject its known
-partials into the reverse tape via `CheckpointCallback::computeAdjoint`. This is
-odelia's compatibility seam for plant's leaf-optimizer forward-mode sensitivity and
-the TF24 stomatal IFT — generic (odelia sees inputs, an output, and partials), and
-it replaces the spike's hand-rolled `inject_h0`.
+**(d) `SuppliedDerivative` — accommodating IFT / forward-mode results.** For a value the
+forward pass computes off-tape (a root-find or optimizer result), its partials are known
+analytically but were never recorded. `SuppliedDerivative` injects them into the reverse
+tape via `CheckpointCallback`: it registers the off-tape value as a fresh leaf and, on
+the reverse sweep, increments each input's adjoint by `ybar · ∂y/∂x_i`. This is odelia's
+compatibility seam for plant's leaf-optimizer forward-mode sensitivity and the TF24
+stomatal IFT — generic (odelia sees inputs, an output, and partials). It is a free
+function called from within the forward pass, where the off-tape value actually exists,
+not a pre-declared target.
 
 ---
 
@@ -154,108 +131,88 @@ Each change below is a small in-place modification of a type that already exists
 ### 5.1 Patch — satisfy odelia's System AD contract
 
 The Patch is already the System (`SCM` holds `odelia::ode::Solver<patch_type>`).
-Changes:
 
-- **Uniform `value_type = S`**, replacing the spike's mixed
-  physiology-active/demography-double split (decision 2). Prefer **not** to thread a
-  third template parameter: let the strategy and environment carry the scalar
-  (`T = FF16_Strategy<S>`, `E = FF16_Environment<S>`) and have `Individual`/`Node`/
-  `Species`/`Patch` derive `using value_type = typename T::value_type`. That collapses
-  the spike's `<T,E,S>` to the existing `<T,E>` and matches odelia's `value_type`
-  convention — fewer signatures to touch, and the scalar lives with the types that
-  own the parameters.
-- **Add `set_params(tape, it)` / `set_initial_state(tape, it, t0)`** returning the
-  registered active inputs — the same contract `leaf_thermal_system.hpp` models.
-  This is where traits and birth-rate become active; the map from trait names to
-  registered fields is plant's (§5.2).
+- **Uniform `value_type = S`.** Let the strategy and environment carry the scalar
+  (`T = FF16_Strategy<S>`, `E = FF16_Environment<S>`) and have
+  `Individual`/`Node`/`Species`/`Patch` derive `using value_type = typename
+  T::value_type`. That keeps the existing `<T,E>` template shape, matches odelia's
+  `value_type` convention, and puts the scalar with the types that own the parameters.
+- **`set_params(tape, it)` / `set_initial_state(tape, it, t0)`** returning the registered
+  active inputs — the same contract `leaf_thermal_system.hpp` models. This is where
+  traits and birth-rate become active; the map from trait names to registered fields is
+  plant's (§5.2).
 
 These are methods on the existing Patch, not a new wrapper type.
 
 ### 5.2 Strategy — make traits seedable, keep physiology scalar-templated
 
-The Strategy classes already exist and already expose per-method `template<class S>`
-physiology (`area_leaf<S>`, `update_dependent_aux<S>`). Two minimal changes:
+The Strategy classes already expose per-method `template<class S>` physiology
+(`area_leaf<S>`, `update_dependent_aux<S>`). Two changes:
 
-- **One parameter representation that can be active.** Today the strategy stores
-  double `pars` and the replay carries a *separate* lifted active struct
-  (`TF24ProdPars<AD> p; p.lma = pd.lma; …`). Collapse to a single scalar-templated
-  parameter store so a named trait can be registered active directly (feeding
-  §5.1's `set_params`). This removes the dual representation.
-- **Leaf-optimizer edge.** TF24/TF24f keep their forward-mode leaf solve; expose
-  its sensitivity as an `AnalyticEdge` (§4.2d) rather than the spike's active-`h0`
-  injection.
+- **One parameter representation that can be active.** The strategy stores a single
+  scalar-templated parameter store, so a named trait registers active directly (feeding
+  §5.1's `set_params`) — no separate double `pars` plus a lifted active struct.
+- **Leaf-optimizer edge.** TF24/TF24f keep their forward-mode leaf solve; its sensitivity
+  crosses into the reverse sweep as a `SuppliedDerivative` (§4d).
 
-The existing FF16 (no optimizer) needs only the parameter-store change.
+FF16 (no optimizer) needs only the parameter-store change.
 
-### 5.3 Reductions — scalar-template the model's own quadratures, delete the copies
+### 5.3 Reductions — scalar-template the model's own quadratures
 
-`Species::compute_competition(double height)` **is** the census/light trapezium
-that the gradient layer copies as `canopy_comp_at`; it currently returns `double`.
-Surgical change: **template it (and the patch census integral) on `S`** so the same
-function serves the forward model (`S=double`, unchanged) and the gradient replay
-(`S=active`). Then `inst/include/plant/gradient/{coupled_canopy.h, scm_harvest.h}`
-retire and exactness is structural, not a maintained bit-for-bit copy.
+`Species::compute_competition(height)` **is** the census/light trapezium. Template it and
+the patch census integral on `S`, so one function serves the forward model (`S=double`,
+unchanged) and the gradient replay (`S=active`). Exactness is then structural — the
+gradient reads the model's own reduction, not a maintained bit-for-bit copy.
 
-### 5.4 The replay is `run_mutant` / `run`, differentiated — not a new engine
+### 5.4 The replay is `run` / `run_mutant`, differentiated
 
-The two workflows differentiate two existing runs, and they differ precisely in how
-the canopy (L3, §7) is accessed:
+The two workflows differentiate two existing runs, differing precisely in how the canopy
+(L3, §7) is accessed:
 
 - **Invasion** = differentiate `SCM::run_mutant(p)` with `S=active`. It switches the
-  Patch to the cached resident environment (`set_mutant()`), pins the schedule to
-  the resident `step_history` (`use_ode_times`), and runs — the mutant reads the
-  **frozen** canopy and does not compete with itself (`is_mutant_run` gates
-  `compute_competition`). The derivative through the canopy is zero.
+  Patch to the cached resident environment (`set_mutant()`), pins the schedule to the
+  resident `step_history`, and runs — the mutant reads the **frozen** canopy and does not
+  compete with itself (`is_mutant_run` gates `compute_competition`). The derivative
+  through the canopy is zero.
 - **Resident / total** = differentiate the resident run on the *same* frozen L0/L1
-  schedule, but with the canopy **reconstructed from the active cohorts** (§7, L3
-  reconstructed) so a trait re-shades the stand. It must **not** read the frozen
-  `environment_history` — doing so collapses it to the invasion gradient.
+  schedule, but with the canopy **recomputed live from the active cohorts** so a trait
+  re-shades the stand. It must **not** read the frozen `environment_history` — that
+  collapses it to the invasion gradient.
 
-Either way the three `*_emergent.cpp` engines are replaced by *differentiating the
-SCM we already have*, not a new engine. The resident canopy is re-computed live by
-re-running `compute_environment` on recorded fixed knots (§7.5) — not reconstructed
-from a stand-state cache — so `stand_stage_history` and its variants are retired.
+The resident canopy is re-computed by re-running `compute_environment` on the recorded
+fixed knots (§7), so the SCM is differentiated directly and no per-RK-stage stand-state
+cache is kept.
 
-The spike's paired `*_impl` (R-list) / `*_native` (live-Patch) entry points are a
-migration scaffold — `_impl` was kept only as a finite-difference reference while the
-native path was proven. The design carries only the native path; the `_impl` half is
-not first-class and is dropped once the regression oracle (UX-2) replaces it.
+### 5.5 SCM orchestration
 
-### 5.5 SCM orchestration over odelia's atomic components
+The SCM stays the plant-specific orchestrator; odelia supplies the atoms (`advance_fixed`
+/ `advance_adaptive`, tape). Two orchestration points matter for AD:
 
-The SCM stays the plant-specific orchestrator; odelia supplies the atoms
-(`advance_fixed`/`advance_adaptive`, tape). Two orchestration points matter for AD:
-
-- **Node introductions grow the system; they are not discontinuities.**
-  `run_next_impl` introduces cohorts at scheduled times, then integrates to the
-  next event. When the node schedule is frozen (§7, L0) the introduction times are
-  *constants* (`d(t_intro)/d(trait) = 0`), so introductions add tape variables (a
-  wider state) but inject no discontinuity into the differentiated output. This is
-  exactly why the schedule must be frozen: an adaptive, trait-dependent schedule
-  *would* be non-differentiable. One recording spans the whole run across
-  introductions.
-- **Adaptivity is frozen in layers, not all at once.** The SCM has *four* adaptive
-  constructions that each break differentiability, and they are frozen
-  independently at different depths (the node schedule, the ODE step times, the
-  quadrature/interpolator knots, and — for invasion — the resident environment).
-  These are the "replay levels" of §7, which sets out which levels each gradient
-  needs.
+- **Node introductions grow the system; they are not discontinuities.** When the node
+  schedule is frozen (L0), the introduction times are *constants*
+  (`d(t_intro)/d(trait) = 0`), so introductions add tape variables (a wider state) but
+  inject no discontinuity into the differentiated output. This is exactly why the
+  schedule must be frozen: an adaptive, trait-dependent schedule would be
+  non-differentiable. One recording spans the whole run across introductions.
+- **Adaptivity is frozen in layers, not all at once.** The SCM has four adaptive
+  constructions that each break differentiability, frozen independently at different
+  depths — the replay levels of §7.
 
 ---
 
 ## 6. UX / API / workflow layer
 
-### 6.1 The two workflows (issue #472)
+### 6.1 The two workflows
 
 | Workflow | SCM entry | Environment | Gradient meaning |
 |---|---|---|---|
 | **Resident / total** | `run()` | co-moving (stand re-shades itself) | d(emergent metric)/d(trait), full self-feedback |
 | **Mutant / invasion** | `run_mutant()` | frozen resident canopy | selection gradient: d(rare-mutant fitness)/d(mutant trait) |
 
-The mutant has low density in an established stand: it competes with the residents
-but not with itself, so its fitness gradient holds the environment fixed. Positive
-fitness ⇒ it can invade. This is a genuinely separate workflow, not a mode flag on
-the first — and both are pre-existing SCM capabilities the design differentiates.
+The mutant has low density in an established stand: it competes with the residents but
+not with itself, so its fitness gradient holds the environment fixed (positive fitness ⇒
+it can invade). These are two genuinely separate workflows — pre-existing SCM
+capabilities the design differentiates — not a mode flag on one.
 
 ### 6.2 Gradient semantics
 
@@ -263,315 +220,145 @@ the first — and both are pre-existing SCM capabilities the design differentiat
 |---|---|---|---|
 | Trait, invasion | mutant | 0 (frozen canopy) | the selection gradient; `offspring_production` is always this |
 | Trait, resident | resident | present | species re-shades the stand it lives in |
-| Birth-rate, census metric | resident | present | the frozen part is the trivial identity `metric / birth_rate`; only the resident (canopy-feedback) axis needs a tape — and it is non-trivial, e.g. it **flips the sign of biomass** vs. the identity |
+| Birth-rate, census metric | resident | present | the frozen part is the identity `metric / birth_rate`; the resident (canopy-feedback) axis needs a tape and is non-trivial — it **flips the sign of biomass** vs. the identity |
 | Birth-rate, `d R0/d birth_rate` | mutant framing | — | `d(net_reproduction_ratio)/d(birth_rate)`; the density-feedback axis |
 
-**A key application: the demographic-equilibrium solve.** `d R0/d birth_rate` is the
-plant-side derivative for the Newton solve that finds the equilibrium birth rate
-(R0 = 1) — the resident density at which a strategy sustains itself. It is computed on
-the same coupled replay via the mutant framing (mutant traits = resident; the change
-in mutant fitness as resident density moves is the density feedback). This makes the
-birth-rate gradient not just a sensitivity but the enabling piece for equilibrium and
-invasion analyses — worth first-class support even though the trait gradients are the
-headline.
+**The demographic-equilibrium solve.** `d R0/d birth_rate` is the plant-side derivative
+for the Newton solve that finds the equilibrium birth rate (R0 = 1) — the resident
+density at which a strategy sustains itself. It is computed on the same coupled replay via
+the mutant framing (mutant traits = resident; the change in mutant fitness as resident
+density moves is the density feedback). The birth-rate gradient is therefore not only a
+sensitivity but the enabling piece for equilibrium and invasion analyses.
 
-The resident-vs-frozen distinction is therefore not a minor correction anywhere: the
-canopy feedback can dominate and reverse the sign of a response (biomass under
-birth-rate is the worked example). "Which feedback" is a real modelling choice, not a
+So the resident-vs-frozen distinction is never a minor correction: the canopy feedback can
+dominate and reverse the sign of a response. "Which feedback" is a modelling choice, not a
 tolerance detail.
 
-### 6.3 Public API (unchanged surface)
+### 6.3 Public API
 
-`stand_gradient(scm, metrics, traits, species, feedback=…)` keeps its shape and maps
-to `compute_jacobian(solver, independents(traits, species, birth_rate),
-EmergentFunctional{metrics})`, where `EmergentFunctional` is plant-supplied and
-reuses §5.3's reductions. The R harvest and `Rcpp::as<>` round-trip disappear (the
-functional reads native state on the tape). Adding a metric is a one-kernel change
-in plant that reuses model functions; odelia is untouched.
+`stand_gradient(scm, metrics, traits, species, feedback)` keeps its shape and maps to
+`compute_jacobian(solver, targets(traits, species, birth_rate),
+EmergentFunctional{metrics})`, where `EmergentFunctional` is plant-supplied and reuses
+§5.3's reductions. The R harvest and `Rcpp::as<>` round-trip disappear — the functional
+reads native state on the tape. Adding a metric is a one-kernel change in plant that
+reuses model functions; odelia is untouched.
 
----
+### 6.4 Two orthogonal axes
 
-### 6.4 What each workflow accesses: two orthogonal axes
+A workflow is a choice on **two independent axes**, and separating them removes most of
+the apparent complexity:
 
-A workflow is a choice on **two independent axes**, and separating them removes most
-of the apparent complexity:
-
-- **Replay** — which adaptive constructions must be recorded and replayed fixed
-  (§7). This is a property of the *system*, not the question: the plant SCM always
-  needs L0·L1·L2; a bare ODE (odelia's Lorenz) needs only L1. Plus the ecological
-  choice of **feedback** — resident (canopy re-run, active) vs. invasion (canopy
-  frozen), which is L3.
-- **Functional** — what scalar is differentiated: an **emergent metric** (no
-  observations) or a **likelihood over observations** (§4.2a). Orthogonal to replay.
-
-The workflows are just points in that grid:
+- **Replay** — which adaptive constructions must be recorded and replayed fixed (§7). A
+  property of the *system*, not the question: the plant SCM always needs L0·L1·L2; a bare
+  ODE needs only L1. Plus the ecological choice of **feedback** — resident (canopy
+  re-run, active) vs. invasion (canopy frozen), which is L3.
+- **Functional** — what scalar is differentiated: an emergent metric (no observations) or
+  a likelihood over observations. Orthogonal to replay.
 
 | Priority | Workflow | Replay (system) | Feedback | Functional |
 |---|---|---|---|---|
-| **1 (primary)** | Emergent gradient, resident (forest ecologist) | SCM: L0·L1·L2 | resident (re-run) | emergent metric |
-| **2** | Mutant/invasion fitness (evolutionary ecologist) | SCM: L0·L1·L2 | invasion (frozen) | emergent metric |
-| **3 (advanced)** | Calibration / inference | *same replay as the system needs* | resident | **likelihood over observations** |
+| **1 (primary)** | Emergent gradient, resident | SCM: L0·L1·L2 | resident (re-run) | emergent metric |
+| **2** | Mutant / invasion fitness | SCM: L0·L1·L2 | invasion (frozen) | emergent metric |
+| **3 (advanced)** | Calibration / inference | same replay as the system needs | resident | likelihood over observations |
 
-**Calibration is not a different replay — it is a different functional.** Calibrating
-the plant SCM to data uses the *same* resident replay as workflow 1 (L0·L1·L2) with a
-likelihood functional layered on top: an **addition, not a subtraction**. It looks
-simpler in odelia only because Lorenz is a bare ODE (L1) with no canopy — the ODE-fit
-example is the degenerate case, and its `set_target`/`fit` shape must **not** set the
-plant UX. The emergent workflows (1, 2) are primary because they need no observations;
-calibration is advanced because it additionally requires the user to define targets
-and a likelihood.
+**Calibration is a different functional, not a different replay.** Calibrating the plant
+SCM to data uses the *same* resident replay as workflow 1 with a likelihood functional on
+top — an addition, not a subtraction. The bare-ODE fit (odelia Lorenz, L1 only) is the
+degenerate case; its shape must not set the plant UX. The emergent workflows are primary
+because they need no observations; calibration is advanced because it additionally
+requires the user to define observations and a likelihood.
+
+---
 
 ## 7. Replay levels: four independent freezes
 
-"Differentiate the converged construction" applies at four *distinct* depths in the
+The one record→replay idea (mechanism in
+[`ad-record-replay.md`](./ad-record-replay.md)) applies at four *distinct* depths in the
 SCM. Each freezes a different adaptive construction that would otherwise break
-differentiability; they compose, and a given gradient needs only some of them.
-Treating them as one "frozen schedule" hides which a given gradient needs, so they are
-kept distinct here.
+differentiability; they compose, and a given gradient needs only some.
 
-| Level | Freezes | Captured by | Removes non-diff from | Owner |
-|---|---|---|---|---|
-| **L0 — node schedule** | which cohorts exist and when introduced | `build_schedule`/`refine_schedule`, *before* the adaptive run | adaptive cohort introduction | plant |
-| **L1 — ODE step times** | the adaptive RKCK step selection | `solver.times()` → `advance_target`/`advance_fixed` (pinned replay) | adaptive step-size control | **odelia (exists)** |
-| **L2 — quadrature / interpolator knots** | height-QAG abscissae and the light-spline knots | cached knots (frozen) *or* scalar-templated `QK` (moving nodes) | adaptive quadrature / interpolation refinement | plant (`qk.h`) + odelia spline |
-| **L3 — resident canopy** | the resident environment the focal cohorts read | `save_RK45_cache` (stores *both* frozen env values *and* resident stand state) | see below — **frozen ≠ reconstructed** | plant |
+| Level | Freezes | Removes non-diff from | Owner |
+|---|---|---|---|
+| **L0 — node schedule** | which cohorts exist and when introduced | adaptive cohort introduction | plant |
+| **L1 — ODE step times** | the adaptive RKCK step selection (replay `advance_fixed`) | adaptive step-size control | **odelia** |
+| **L2 — quadrature / interpolator knots** | height-quadrature abscissae and light-spline knots | adaptive quadrature / interpolation refinement | plant + odelia spline |
+| **L3 — resident canopy** | the resident environment the focal cohorts read | canopy feedback (frozen for a mutant) | plant |
 
-**L1 is the ODE-fit case (calibration), and it already works — but it is not the
-plant driver (§6, R-interface).** odelia's own AD test (`test-ad-workflow.R`) runs a
-Lorenz solve adaptively, captures `times()`, and replays pinned via
-`set_target`/`advance_target` — *no environment cache, just the resolved ODE
-schedule*. It needs L1 alone.
+L1 alone is the bare-ODE calibration case: run adaptively, capture `times()`, replay
+`advance_fixed(recorded_steps())` — no environment cache, just the resolved schedule.
 
-**L2 has two variants, and #472 flags the harder one.** For the resident light
-spline, the knots are frozen (positions) and the values active — odelia's
-differentiable spline (§4.1). For a census integrated over height, the integration
-bound *is* an active plant height, so the Gauss–Kronrod **nodes move**: this needs
-the scalar-templated `QK` (`qk.h`, already written for #472) rather than a
-frozen-node replay, which "would miss" the moving-node sensitivity.
+**L2 has two variants.** For the resident light spline, the knots are frozen (positions)
+and the values active — odelia's differentiable spline. For a census integrated over
+height the integration bound *is* an active plant height, so the quadrature **nodes
+move**: this needs the scalar-templated `QK`, not a frozen-node replay, which would miss
+the moving-node sensitivity.
 
-**L3 is accessed two *different* ways — and this is the correctness crux.** The
-resident run records the frozen resident environment *values* (`environment_history`)
-and the light-spline knot *positions* (§7.5); the two gradients diverge on which they
-use. (The spike additionally caches full stand state per RK stage,
-`stand_*_stage_history`; §7.5 shows that is unnecessary — record knots, re-run the
-canopy.)
+**L3 is the correctness crux — frozen ≠ reconstructed.** The resident run records the
+resident environment *values* and the light-spline knot *positions*; the two gradients
+diverge on which they read.
 
-- **Invasion (frozen):** a rare mutant reads the cached `environment_history` as a
-  **constant** — the derivative through the canopy is zero by construction. This is
-  `run_mutant` (`is_mutant_run` suppresses self-competition). Correct for a rare
-  invader.
-- **Resident / total (re-run):** the canopy is **recomputed live** by re-running
-  `compute_environment` on the *recorded* light-spline knots (§7.5) with the active,
-  re-evolved cohorts, so a trait re-shades the stand through `area_leaf`.
-  **Replaying the frozen environment here would silently give the invasion gradient —
-  the self-shading cross term would be missing.** The resident total gradient
-  therefore does *not* read the frozen env; it re-runs the model's own light on fixed
-  knots. (No `stand_stage_history` — §7.5.)
+- **Invasion (frozen):** a rare mutant reads the recorded environment as `double`
+  background — off the tape entirely, so the derivative through the canopy is zero by
+  construction (not an active constant with a zeroed derivative). This is `run_mutant`.
+- **Resident / total (re-run):** the canopy is recomputed live by re-running
+  `compute_environment` on the recorded knots with the active, re-evolved cohorts, so a
+  trait re-shades the stand through `area_leaf`. **Replaying the frozen environment here
+  would silently give the invasion gradient** — the self-shading cross term would be
+  missing. Only the knot *positions* are recorded; the cohort values come from the replay
+  itself, so no per-RK-stage stand-state cache is needed.
 
-### Which workflow needs which levels
-
-The replay levels are a property of the **system**, not the workflow: any gradient of
-the plant SCM needs L0·L1·L2; a bare ODE needs only L1. Feedback (L3) and the
-functional are the orthogonal choices (§6.4).
+### Which gradient needs which levels
 
 | Gradient | L0 | L1 | L2 | L3 |
 |---|:--:|:--:|:--:|:--:|
-| Bare-ODE fit (odelia Lorenz — the degenerate case) | | ✅ | | |
+| Bare-ODE fit (odelia Lorenz — degenerate) | | ✅ | | |
 | Offspring, invasion | ✅ | ✅ | | frozen |
 | Census (LAI/biomass/basal area), resident | ✅ | ✅ | ✅ | **re-run** |
 | Census, invasion | ✅ | ✅ | ✅ | frozen |
 | SCM calibration to data | ✅ | ✅ | ✅ | re-run |
 
-The last two rows share the L0·L1·L2·L3-re-run replay; they differ only in the
-functional (emergent metric vs. likelihood) — the point of §6.4.
+The last two rows share the L0·L1·L2·L3-re-run replay and differ only in the functional
+(emergent metric vs. likelihood) — the point of §6.4.
 
-### The fixed comb still makes functionals simple
-
-With L0–L1 frozen, the emergent functionals are simple reductions over a fixed set
-of cohorts. Offspring is a **constant-weighted sum** `Σ tw_i · offspring_i` (fixed
-introduction times ⇒ constant weights). A census reduction is
-`Species::compute_competition` scalar-templated (§5.3) — reused, not re-derived —
-with L2 supplying the (moving or frozen) quadrature nodes. The design keeps the
-*same* quadratures the model already uses and differentiates them; it adds no new
-integration.
+**The fixed comb keeps functionals simple.** With L0–L1 frozen, the emergent functionals
+are reductions over a fixed set of cohorts. Offspring is a constant-weighted sum
+`Σ tw_i · offspring_i` (fixed introduction times ⇒ constant weights). A census reduction
+is `Species::compute_competition` scalar-templated (§5.3), with L2 supplying the (moving
+or frozen) quadrature nodes. The design differentiates the *same* quadratures the model
+already uses; it adds no new integration.
 
 ---
 
-### 7.5 One primitive under every level: record the adaptive nodes, replay fixed
+## 8. Strategy coverage and the cross-sensitivity term
 
-The four levels look like four mechanisms but are one idea. Every adaptive numerical
-construction in the SCM — the RKCK stepper, the light interpolator
-(`AdaptiveInterpolator` refining knots over height every step), the crown-depth
-quadrature (`qag.h`) — exists to *discover* where to place nodes to hit an error
-tolerance **without knowing the answer**. On a replay we already know the answer, so
-adaptivity is pure overhead: record where the first (double, adaptive) pass placed
-its nodes, then replay on those nodes held fixed, with the scalar active. No
-refinement loop runs on the AD pass.
-
-| Adaptive construction | Records | Replays as | Status |
+| Strategy | Offspring | Census, invasion | Census, resident |
 |---|---|---|---|
-| RKCK stepper | step times (`solver.times()`) | `advance_fixed` | odelia — exists |
-| light interpolator | knot positions (`AdaptiveInterpolator` → `get_x()`) | `basic_interpolator<S>`, frozen x + active y | odelia primitive exists |
-| crown-depth quadrature | QAG subdivision (or none — a fixed rule) | scalar-templated `QK<S>` on fixed abscissae | `qk.h` exists; recording is the one gap |
+| FF16 (no leaf optimizer) | ✅ | ✅ | ✅ |
+| TF24 / TF24f (leaf optimizer) | ✅ | ✅ | ✅ (via the cross-term below) |
 
-`basic_interpolator<S>` is the interpolator instance of this: the ordinary
-interpolator with the value scalar templated, so a frozen set of recorded knots
-carries active values differentiably (via `basic_spline<S>`). The stepper
-(`advance_fixed`) and the quadrature (fixed `QK<S>`) are the same shape — record
-positions on the adaptive pass, replay values on the fixed positions.
-
-**This eliminates `stand_stage_history`.** The spike caches the resident stand state
-per RK stage so it can *reconstruct* the light without re-running
-`compute_environment`. But if the replay simply **re-runs the model's own
-`compute_environment` on the recorded knots with the active, re-evolved cohorts**,
-the light is recomputed live and responds to traits — no stand-state cache. What must
-be recorded per step is only the **knot positions** (a short vector of heights); the
-cohort values come from the replay itself. The heavy `stand_*_stage_history` /
-`stand_newnode_*` / all-species caches in `patch.h` are not needed under the
-full-scalar re-run.
-
-**The resident and calibration workflows share one replay.** Both are "run adaptive
-once, record the nodes, replay fixed with the active scalar." They differ in only two
-things:
-
-1. the **functional** — an emergent metric (no observations) vs. a likelihood over
-   observations; and
-2. **how many adaptive constructions are in replay mode** — calibration replays only
-   the ODE stepper (L1); the emergent resident gradient also replays the light
-   interpolator and crown quadrature (L2).
-
-The resident canopy is live-active (self-shading) simply because `compute_environment`
-re-runs on active cohorts; the invasion gradient reuses the *recorded double* light
-spline unchanged (frozen). One record-then-replay-fixed primitive, applied at whichever
-levels a gradient needs.
-
-**Boundary of applicability (measured on the spike).** Fixed-node replay assumes the
-recorded nodes stay adequate when the scalar goes active. This holds for FF16 (bounded,
-closed-form light response) and for TF24/TF24f at moderate horizons. It **fails for the
-TF24f resident coupled feedback at long patch lifetimes**: the `log_density`↔canopy loop
-is stiff (a deeply-shaded cohort carries a large leaf `dprofit/dL`), and the live SCM
-tames it with *adaptive* sub-stepping that a fixed schedule cannot reproduce — the double
-frozen-step replay itself drifts (env err ~1e-6 at H4 → ~2e-2 at H5+). The true gradient
-exists (full-SCM finite differences are finite); only the fixed replay diverges. So the
-primitive is the right default, but stiff coupled horizons need **adaptive sub-stepping in
-the replay** (future hardening, §11) — not a universal guarantee. (This is a milder
-relative of the #550 density blow-up: same size-density equation, but a replay artifact
-rather than a genuine caustic.)
-
-### 7.6 Mechanism and abstraction
-
-Two complementary mechanisms implement §7.5, and both already exist in odelia in part.
-
-**Recording is an opt-in System hook, detected at compile time.** odelia's stepper
-already does exactly this for the RK45 cache: a trait (`has_cache` detecting
-`cache_RK45_step`) makes the generic stepper call `system.cache_RK45_step()` per RK
-stage and `system.cache_ode_step()` per step, compiling to a **zero-cost no-op** for
-systems that don't provide the hook (`ode_interface.hpp`, `ode_step.hpp:77`,
-`ode_solver_internal.hpp:83`). odelia never learns what is cached. The record side of
-§7.5 reuses these hook points; the simplification is mostly **shrinking what plant
-records through them** (knot positions, not `stand_stage_history`).
-
-Recommendation: keep the opt-in-hook design (the system opts in; odelia stays
-agnostic; an absent hook compiles away), but express new hooks with **C++20 concepts +
-`if constexpr`** rather than more `enable_if` SFINAE. The project is already
-`CXX_STD = CXX20`, and a `requires`-based `Recordable` concept reads far better than
-`std::enable_if<has_cache<System>::value>` for a developer meeting the code for the
-first time (optionally retrofitting the existing traits for consistency).
-
-**Replay-fixed is a component mode, expressed by scalar-templating over frozen
-nodes.** The abstraction is one idea reused three times, and it is minimal:
-
-- `basic_spline<S>` — the ttk592 spline templated on the *value* scalar (knot
-  positions stay `double`); this is the interpolation math itself.
-- `basic_interpolator<S>` — a thin usage layer over it (domain, extrapolation, eval,
-  the R seam). The two-layer split (math vs. usage) is worth keeping.
-- `QK<S>` — the fixed Gauss–Kronrod rule with the integrand scalar templated and the
-  abscissae `double`; `advance_fixed` is the stepper instance.
-
-"Freeze the nodes, template the value/integrand scalar" is the smallest construct that
-makes a fixed-node numeric differentiable, and it is already proven for the
-interpolator. Extending it to `QK<S>` is endorsed; `QK<S>` can be a single
-scalar-templated primitive — it need not mirror the spline/interpolator two-layer
-split, which keeps the odelia numerics surface small.
-
-## 8. Strategy coverage and the cross-sensitivity gap
-
-| Strategy | Offspring | Census, invasion | Census, resident | Blocker |
-|---|---|---|---|---|
-| FF16 | ✅ | ✅ | ✅ | — (no leaf optimizer) |
-| TF24f | ✅ | ✅ (long-horizon gate) | partial | stiff feedback at long lifetime |
-| TF24 | ✅ | ✗ in spike | ✗ in spike | **leaf-optimizer cross-sensitivity** |
-
-**The gap:** TF24/TF24f solve a per-cohort leaf optimum; a census metric depends on
-it, so a trait shift moves the optimum → growth → census density. The spike's
-*linearised, frozen* harvest injects the leaf sensitivity along the focal path but
-zeroes this cross-term through the density.
-
-**Why the full-scalar design plausibly closes it:** with the whole `run_mutant`
-replay on one tape and the leaf IFT delivered as an `AnalyticEdge` (§4.2d) rather
-than a frozen-path injection, the reverse sweep traverses density→optimum→trait
-natively. **This is the single highest-risk claim; the §-prototype in `ad-issues.md`
-(PROTO-2) must confirm it** before TF24 census is guaranteed for v1 (decision 7).
+TF24/TF24f solve a per-cohort leaf optimum, and a census metric depends on it: a trait
+shift moves the optimum → growth → census density. The design captures this because the
+whole `run_mutant` replay runs on **one tape** with the leaf IFT delivered as a
+`SuppliedDerivative` (§4d): the reverse sweep traverses density→optimum→trait natively,
+rather than a linearised, frozen harvest that injects the leaf sensitivity along the
+focal path but zeroes the cross-term through the density. This full-scalar path is what
+puts TF24 census on the same footing as FF16.
 
 ---
 
-## 9. Scalar-cost measurement (validates decision 2)
+## 9. Boundaries
 
-Before building the production path: implement the FF16 frozen cohort as a
-uniform-`value_type` System, gradient one metric, and compare `tape.getMemory()` /
-wall-clock against the spike's mixed engine (`scripts/bench_gradient.R`). Outcomes:
-(a) within a small constant → ship uniform scalar; (b) decisively worse → keep a
-mixed scalar but as an odelia "frozen input" concept (inputs with a permanent zero
-adjoint), not a hand-threaded template axis; (c) ambiguous → uniform for
-maintainability. This is PROTO-1.
-
----
-
-## 10. Migration (spike as oracle)
-
-Snapshot the spike's validated Jacobians to a regression fixture and assert
-bit-identity (relocations) or a documented noise floor (FP-reorder paths) at every
-step, plus the existing AD-vs-FD physics tests. Build order and dependencies are in
-[`ad-issues.md`](./ad-issues.md); in brief: odelia foundation (functional shape,
-`compute_jacobian`, `Independents`/`AnalyticEdge`) → scalar-cost spike → FF16
-invasion via differentiated `run_mutant` → FF16 resident + spline → TF24/TF24f (+
-cross-sensitivity prototype) → delete the engines, R harvest, and local tapes.
-
----
-
-## 11. Risks and open areas
-
-- **TF24 census cross-sensitivity (§8)** — highest risk; gated on PROTO-2.
-- **Scalar cost (§9)** — default unproven; gated on PROTO-1.
-- **`AnalyticEdge`/`CheckpointCallback` ergonomics (§4.2d, §5.2)** — mechanism
-  exists but is unused in plant; needs PROTO-3 to fix its API.
-- **Metric set (§6.3)** — enumerate the required metrics + kernels so the interface
-  covers them in one shape.
-- **Resident TF24f at long horizon (§7.5, §8)** — the fixed-step replay cannot tame the
-  stiff `log_density`↔canopy feedback that the adaptive SCM does. True horizon extension
-  needs adaptive sub-stepping in the replay; likely stays gated in v1 (clear error, not a
-  wrong number), with the gate driven by the double replay's env error.
-- **Boundary / zero-height cohort trap (correctness).** A cohort introduced on the final
-  step (`birth == N`) can sit at zero height, where `area_leaf = (h/a_l1)^(1/a_l2)`
-  differentiates to `0·log(0) = NaN` (it also biased the *value*). The spike fixes this by
-  establishing `birth ≥ N` cohorts at the seed height `h0`; the port must carry that fix.
-  A known, concrete AD trap — worth an explicit test.
-
----
-
-## Appendix: source references
-
-**odelia** — `inst/include/XAD/{Jacobian,CheckpointCallback,Interface}.hpp`;
-`inst/include/odelia/{ode_fit,ode_solver,spline,interpolator}.hpp`;
-`inst/examples/leaf_thermal/src/leaf_thermal_system.hpp`; `ARCHITECTURE.md`.
-
-**plant** — `inst/include/plant/scm.h` (`run`, `run_next_impl`, `run_mutant`,
-`Solver<patch_type>`); `inst/include/plant/patch.h` (`set_mutant`,
-`introduce_new_nodes`, `environment_history`/`step_history`, `is_mutant_run`);
-`inst/include/plant/species.h` (`compute_competition` — the census trapezium, still
-`double`); `inst/include/plant/models/ff16_strategy.h` (`template<class S>`
-physiology; double `pars`); `src/{ff16,tf24,tf24f}_emergent.cpp` (the parallel
-engines, five local tapes, `inject_h0`); `src/leaf_model.cpp`,
-`src/tf24_strategy.cpp` (forward-mode leaf IFT); `R/*_emergent_gradient.R` (harvest,
-round-trip, `frozen`/`resident` feedback); `inst/include/plant/gradient/*` (the
-reduction copies to retire); `notes/ad-refactor-optimize-roadmap.md`.
+- **Stiff TF24f resident coupling at long patch lifetimes.** Fixed-node replay assumes
+  the recorded nodes stay adequate when the scalar goes active. This holds for FF16 and
+  for TF24/TF24f at moderate horizons. It fails for the TF24f resident coupled feedback at
+  long lifetimes: the `log_density`↔canopy loop is stiff, and the live SCM tames it with
+  *adaptive* sub-stepping that a fixed schedule cannot reproduce — the frozen-step replay
+  itself drifts. The true gradient exists (full-SCM finite differences are finite); only
+  the fixed replay diverges. The primitive is the right default; the stiff coupled horizon
+  needs adaptive sub-stepping in the replay, and until it has that the case is gated by a
+  clear error (driven by the double replay's environment error), never a wrong number.
+- **Zero-height cohort trap.** A cohort introduced on the final step (`birth == N`) can
+  sit at zero height, where `area_leaf = (h/a_l1)^(1/a_l2)` differentiates to
+  `0·log(0) = NaN` (it also biases the value). Establishing `birth ≥ N` cohorts at the
+  seed height `h0` fixes both — a concrete AD trap that carries an explicit test.
+- **Second order (Hessian) is out of scope.**

--- a/notes/ad-design/ad-issues.md
+++ b/notes/ad-design/ad-issues.md
@@ -1,0 +1,262 @@
+# AD infrastructure: work items, dependencies, and build order
+
+Companion to [`ad-infrastructure-design.md`](./ad-infrastructure-design.md).
+Each item is scoped to one layer (odelia / plant / UX) or is a de-risking
+prototype. Items are deliberately small; where a design is still open the item
+says what must be decided and by which prototype.
+
+**Legend.** Class: **CP** critical path · **PROTO** de-risking prototype (gates a
+CP item) · **NTH** nice-to-have. Repo: `odelia` / `plant` / `meta` (docs, fixtures).
+
+---
+
+## Prototypes (do first — each can move a decision)
+
+### PROTO-1 — Scalar-cost measurement · repo: plant · gates PLANT-1, decision 2
+Implement the FF16 frozen cohort as a uniform-`value_type` odelia System, gradient
+one metric, compare `tape.getMemory()` and wall-clock to the spike's mixed engine
+on the canonical cases. **Output:** a number that chooses uniform scalar vs. an
+encapsulated "frozen input" fallback. Blocks committing to the full-scalar Patch.
+
+### PROTO-2 — TF24 census cross-sensitivity · repo: plant · gates TF24 census, decision 7
+One TF24 cohort; gradient a density-dependent census metric with the leaf-optimizer
+IFT delivered as an on-tape `AnalyticEdge`; check against finite differences.
+**Output:** confirmation (or refutation) that the full-scalar `run_mutant` replay
+captures the density→optimum cross-term. **Highest risk in the whole design** — run
+early; a refutation rescopes TF24 census out of v1.
+
+### PROTO-3 — `AnalyticEdge` / `CheckpointCallback` ergonomics · repo: odelia → plant · feeds ODELIA-3
+Minimal `CheckpointCallback` that injects a known d(out)/d(in) into a reverse tape;
+reproduce one leaf-optimizer sensitivity from the spike bit-for-bit. **Output:** the
+`AnalyticEdge` API shape. Prerequisite for the clean version of PROTO-2.
+
+---
+
+## odelia layer (generic, plant-agnostic)
+
+### ODELIA-1 — Generalize `compute_gradient` to an arbitrary functional · CP
+Replace the hard-coded `sum_of_squares` with a caller-supplied functional
+`std::vector<S> f(const System& solved)`. Keep `sum_of_squares`/`advance_target` as
+a prebuilt instance. **Depends on:** —. **Blocks:** ODELIA-2, PLANT-4.
+
+### ODELIA-2 — `compute_jacobian` (reverse, row-sweep) · CP
+Record once, one adjoint sweep per output row (adjoint `XAD::computeJacobian`
+pattern), reusing the Solver-owned tape. **Depends on:** ODELIA-1. **Blocks:**
+PLANT-4, UX-1.
+
+### ODELIA-3 — `Independents` + `AnalyticEdge` · CP
+The "differentiate w.r.t. what" bundle (renamed from `Seeds`) and the analytic-edge
+injection built on `CheckpointCallback`. **Depends on:** PROTO-3. **Blocks:**
+PLANT-2 (traits), PLANT-6 (leaf edge).
+
+### ODELIA-4 — odelia-native test harness for the AD surface · CP-support
+The spike's Jacobian test harness lives in plant; the machinery moving into odelia
+needs coverage **independent of plant**, on odelia's own example systems (Lorenz,
+leaf_thermal). Scope (implementation may be deferred to another dev, but the tests
+are release-gating):
+- **`compute_gradient` / `compute_jacobian`** — value + gradient against finite
+  differences on a closed-form system; Jacobian shape/row-sweep on a multi-output
+  functional; tape reuse across repeated calls. **Depends on:** ODELIA-1, ODELIA-2.
+- **`AnalyticEdge` (ODELIA-4b)** — an off-tape root-find whose IFT edge is injected
+  via `CheckpointCallback`, checked against the analytic derivative and against
+  differentiating the solve directly. **Depends on:** ODELIA-3.
+- **Functional shape (ODELIA-4b)** — a custom functional (not `sum_of_squares`) plus
+  the `sum_of_squares`/`advance_target` instance, to prove the seam is functional-
+  agnostic. **Depends on:** ODELIA-1.
+- **Record/replay-fixed (ODELIA-4a)** — a system with an adaptive interpolator and a
+  quadrature: assert the fixed-node replay reproduces the adaptive run's value and
+  that gradients match finite differences (design §7.5–7.6). **Depends on:** ODELIA-6.
+
+These are the odelia-side equivalents of the spike's plant Jacobian fixture; plant's
+AD-vs-AD oracle (UX-2) still gates the plant ports separately.
+
+### ODELIA-5 — Document the AD API contract in `ARCHITECTURE.md` · CP-support
+Extend the existing Tape-linking contract to cover the AD *API* (functional shape,
+`Independents`, edges) so plant depends on a versioned odelia surface. **Depends
+on:** ODELIA-1..3.
+
+### ODELIA-6 — Record-adaptive / replay-fixed numerics (the one replay primitive) · CP
+Make odelia's adaptive numerics support "record node placement on the double pass,
+replay on fixed nodes with the active scalar" uniformly (design §7.5–7.6). Two
+mechanisms, both partly present:
+- **Record via opt-in System hooks.** The stepper already calls `cache_RK45_step` /
+  `cache_ode_step` when a System provides them (`has_cache` trait; zero-cost no-op
+  otherwise). Reuse these hook points; shrink the payload to knot positions (not
+  `stand_stage_history`). Express any *new* hooks with C++20 concepts + `if
+  constexpr` rather than more `enable_if` SFINAE (design §7.6).
+- **Replay-fixed components.** `advance_fixed` (stepper) and `basic_interpolator<S>`
+  (frozen knots, active values) exist; the **gap** is a scalar-templated fixed-rule
+  `QK<S>` that consumes a recorded QAG subdivision — or a prototype showing a single
+  fixed rule suffices. `QK<S>` stays single-layer (no interpolator-style wrapper).
+
+**Depends on:** —. **Blocks:** PLANT-4a, PLANT-5a. **Tested by:** ODELIA-4a.
+
+---
+
+## plant layer (surgical changes to existing types)
+
+### PLANT-1 — Uniform `value_type = S` on Patch/Species/Node/Individual · CP
+Collapse the mixed active/frozen `<T,E,S>` into one uniform scalar. **Depends on:**
+PROTO-1 (decides uniform vs. fallback). **Blocks:** PLANT-3, PLANT-4.
+
+### PLANT-2 — Single scalar-templated Strategy parameter store · CP
+Remove the dual double-`pars` / lifted-active-struct representation so a named
+trait can be registered active. **Depends on:** —. **Blocks:** PLANT-3.
+
+### PLANT-3 — Patch `set_params` / `set_initial_state` (odelia AD contract) · CP
+Implement the System contract on Patch; map trait names + birth-rate to registered
+active inputs. **Depends on:** PLANT-1, PLANT-2, ODELIA-3. **Blocks:** PLANT-4.
+
+### PLANT-4 — Differentiate `run_mutant` (invasion gradient) · CP
+The FF16 invasion gradient as `compute_jacobian` through the existing `run_mutant`
+with `S=active`: canopy read **frozen** from `environment_history` (derivative
+through it is zero), `is_mutant_run` suppresses self-competition. Retires
+`ff16_emergent.cpp`. **Depends on:** ODELIA-2, PLANT-3. **Blocks:** PLANT-5, PLANT-7.
+
+### PLANT-4a — Resident/total gradient: re-run the canopy on recorded knots · CP
+The resident gradient on the same frozen L0/L1 schedule with the canopy **re-run
+live**: re-run `compute_environment` on the *recorded* light-spline knots (§7.5)
+with the active cohorts, so a trait re-shades the stand. **Do NOT** read the frozen
+env (that silently yields the invasion gradient, missing self-shading) and **do NOT**
+build `stand_*_stage_history` — record only the knot positions; cohort values come
+from the replay. **Depends on:** PLANT-4, PLANT-5, PLANT-5a, ODELIA-6. **Blocks:**
+PLANT-7 (census resident).
+
+### PLANT-5 — Scalar-template `Species::compute_competition` + census; reuse · CP
+Template the reductions on `S`; delete `gradient/{coupled_canopy.h, scm_harvest.h}`.
+Enables the resident/total gradient (active canopy). **Depends on:** PLANT-1.
+**Blocks:** PLANT-7.
+
+### PLANT-5a — L2 replay: moving-node `QK` + frozen light-spline knots · CP
+Wire the census height-integral to the scalar-templated Gauss–Kronrod `QK`
+(`qk.h`, already written for #472) so the active plant-height bound propagates
+through the *moving* quadrature nodes; reconstruct the resident light on odelia's
+frozen-knot differentiable spline (design §7, L2). This is the level a frozen-node
+replay misses. **Depends on:** PLANT-5. **Blocks:** census gradients (UX-3 metrics).
+
+### PLANT-6 — Leaf-optimizer `AnalyticEdge` for TF24/TF24f · CP
+Route the forward-mode leaf sensitivity through the odelia edge. **Depends on:**
+ODELIA-3, PROTO-2. **Blocks:** PLANT-7 (TF24/TF24f).
+
+### PLANT-7 — Port TF24 / TF24f; delete parallel engines · CP
+TF24/TF24f as the same differentiated `run`/`run_mutant`; remove
+`tf24_emergent.cpp`, `tf24f_emergent.cpp`, the R harvest, and the five local tapes.
+**Depends on:** PLANT-4, PLANT-5, PLANT-6.
+
+### PLANT-8 — Frozen light on odelia's differentiable spline · CP-support
+Build the cached resident light on `basic_spline<S>` so schedule-freeze is a
+primitive. **Depends on:** PLANT-5. Folds into PLANT-4/5.
+
+### PLANT-9 — Un-skip the 7 FF16 AD tests · NTH-then-CP
+Once AD runs on odelia's tape/load path, convert the skipped tests to exercise the
+compiled path. **Depends on:** PLANT-4.
+
+### PLANT-10 — Birth-rate gradient + `d R0/d birth_rate` (equilibrium) · CP (FF16)
+`birth_rate_gradient(scm, metrics, species)` on the coupled resident replay (the
+frozen part is the identity `metric/birth_rate`; the resident axis needs a tape and
+can flip signs), plus `d(net_reproduction_ratio)/d(birth_rate)` = dR0/db via the
+mutant framing — the plant-side derivative for the R0 = 1 equilibrium Newton solve
+(design §6.2). FF16 single- then multi-species in v1; TF24f gated like its trait
+gradient. **Depends on:** PLANT-4a. **Blocks:** downstream equilibrium/invasion tools.
+
+### PLANT-11 — Boundary / zero-height cohort fix + test · CP (correctness)
+Establish `birth ≥ N` cohorts at the seed height `h0` so
+`area_leaf = (h/a_l1)^(1/a_l2)` does not differentiate to `0·log(0) = NaN` (design
+§11). Carry the spike's fix; add an explicit AD test at the final-step boundary.
+**Depends on:** PLANT-4. Cheap but load-bearing — the NaN also biased the value.
+
+---
+
+## UX / API / workflow
+
+### UX-1 — `stand_gradient()` stable surface · CP
+Keep the public signature; forward to `compute_jacobian` + `EmergentFunctional`.
+**Depends on:** ODELIA-2, PLANT-4.
+
+### UX-2 — Regression oracle fixture · CP (do alongside migration)
+Snapshot the spike's validated Jacobians to `tests/testthat/fixtures/
+gradient-baseline.rds`; two-tier tolerance (bit-identity / noise floor). **Depends
+on:** —. **Gates:** every PLANT-* merge.
+
+### UX-3 — Metric set + kernels · resolved
+Shipped set: **LAI, biomass, basal area** (census, reusing the scalar-templated
+`compute_competition`) and **offspring_production**. Each is one `psi` kernel behind
+the `EmergentFunctional` shape; mean-height and other additions are tutorial-level
+extensions (design R-interface §6.4), not release scope.
+
+### UX-4 — Gradient benchmark harness · NTH
+`scripts/bench_gradient.R` timing the sub-costs; also feeds PROTO-1. **Depends
+on:** —.
+
+---
+
+## R boundary (see [`ad-r-interface.md`](./ad-r-interface.md))
+
+Governing invariant: only `double` crosses the R boundary; active types are
+C++-internal and ephemeral. These items are the R-facing side of the driver work.
+
+### RIF-1 — odelia `Solver_gradient`/`Solver_jacobian`/`value_and_gradient` on the double handle · CP
+Retire the `bool active` flag and the R-visible `ActiveSystemType` XPtr; the driver
+owns the active system internally. Include a combined `value_and_gradient(p)` that
+returns both from one recording (optimizer loops call `fn`/`gr` separately; sharing
+the tape halves the work — see user story §6.3). **Depends on:** ODELIA-1, ODELIA-2.
+Removes the type-confusion hazard in `Solver_fit_impl`.
+
+### RIF-2 — odelia `rebind` lift (double → active) · CP
+A System contract so the driver constructs the active system generically instead of
+per-example hand-construction. **Depends on:** —. **Blocks:** RIF-1.
+
+### RIF-3 — odelia opaque tape/active-scratch cache on the double Solver · CP-support
+Tape reuse within a Jacobian and across optimizer calls, without R seeing it.
+**Depends on:** RIF-1.
+
+### RIF-4 — odelia policy: no `wrap`/`as` for active types · NTH
+Keep `xad::value`/`xad::derivative` the only extraction; prevent accidental
+derivative loss.
+
+### RIF-5 — plant single `stand_gradient_cpp` entry (RcppR6 handle, C++ dispatch) · CP
+One hand-written export taking the RcppR6 SCM (pointer unwrap only), dispatching
+strategy/feedback in C++. **Depends on:** ODELIA-2, PLANT-4.
+
+### RIF-6 — plant native-pointer harvest; delete `Rcpp::as<*_Environment>` · CP
+The active replay reads the live Patch by pointer; no serialisation round-trip.
+**Depends on:** PLANT-4, PLANT-5. (Same work as the native harvest in those items,
+viewed from the boundary.)
+
+### RIF-7 — plant thin `stand_gradient()` R wrapper · CP-support
+Remove R-side branching across native/impl/resident variants. **Depends on:**
+RIF-5.
+
+---
+
+## Build order (critical path)
+
+```
+PROTO-3 ─► ODELIA-3 ─┐
+ODELIA-1 ─► ODELIA-2 ─┼─► PLANT-3 ─► PLANT-4 ─► PLANT-4a ─► PLANT-7
+PROTO-1 ─► PLANT-1 ───┘        ▲          │         ▲
+PLANT-2 ──────────────────────┘          ├─► PLANT-5 ─► PLANT-5a ┘
+ODELIA-6 ─► (PLANT-4a, PLANT-5a) ─────────┤   PROTO-2 ─► PLANT-6 ─► PLANT-7
+UX-1 ◄─ PLANT-4 ; ODELIA-4/4a/4b ◄─ ODELIA-1..3,6 (odelia-native tests)
+UX-2 (oracle) ── gates every PLANT-* merge ; UX-3 resolved (input)
+```
+
+**Sequencing notes.**
+- The three prototypes are independent and come first; PROTO-2 is the one that can
+  rescope the release, so front-load it.
+- odelia's foundation (ODELIA-1..3), the record/replay primitive (ODELIA-6), and the
+  scalar decision (PROTO-1 → PLANT-1) can proceed in parallel; they converge at
+  PLANT-3/4a.
+- odelia-native tests (ODELIA-4/4a/4b) track their features and gate the odelia
+  release independently of plant; plant's oracle (UX-2) gates the plant ports.
+- FF16 invasion (PLANT-4) is the first end-to-end proof and should land before the
+  resident path (PLANT-4a) and any TF24 work.
+- Nothing merges without UX-2 (the AD-vs-AD oracle) green.
+
+## Not in this release
+- Second-order / Hessian (`fwd_adj`).
+- **Adaptive sub-stepping in the replay** — the future hardening that would extend the
+  TF24f resident coupled gradient past its stiff long-horizon limit (§7.5). v1 gates it
+  with a clear error driven by the double replay's env error, never a wrong number.
+- Full resident-feedback TF24f at long patch lifetime (the stiffness limit above).
+- Moving plant's leaf-level forward-mode AD into odelia (stays plant-local).

--- a/notes/ad-design/ad-issues.md
+++ b/notes/ad-design/ad-issues.md
@@ -20,33 +20,42 @@ encapsulated "frozen input" fallback. Blocks committing to the full-scalar Patch
 
 ### PROTO-2 — TF24 census cross-sensitivity · repo: plant · gates TF24 census, decision 7
 One TF24 cohort; gradient a density-dependent census metric with the leaf-optimizer
-IFT delivered as an on-tape `AnalyticEdge`; check against finite differences.
+IFT delivered as an on-tape `SuppliedDerivative`; check against finite differences.
 **Output:** confirmation (or refutation) that the full-scalar `run_mutant` replay
 captures the density→optimum cross-term. **Highest risk in the whole design** — run
 early; a refutation rescopes TF24 census out of v1.
 
-### PROTO-3 — `AnalyticEdge` / `CheckpointCallback` ergonomics · repo: odelia → plant · feeds ODELIA-3
+### PROTO-3 — `SuppliedDerivative` / `CheckpointCallback` ergonomics · repo: odelia → plant · feeds ODELIA-3
 Minimal `CheckpointCallback` that injects a known d(out)/d(in) into a reverse tape;
 reproduce one leaf-optimizer sensitivity from the spike bit-for-bit. **Output:** the
-`AnalyticEdge` API shape. Prerequisite for the clean version of PROTO-2.
+`SuppliedDerivative` API shape. Prerequisite for the clean version of PROTO-2.
 
 ---
 
 ## odelia layer (generic, plant-agnostic)
 
+> **Status: this whole layer is implemented** (ODELIA-1..6, RIF-1..3, PROTO-3), on a
+> stack of PRs on the odelia fork. The items below are kept for the dependency map and
+> build order; the settled names are `DifferentiationTargets` (was `Independents`),
+> `SuppliedDerivative` (was `AnalyticEdge`), `record_stage`/`record_ode_step`/`replay_step`
+> + `has_recorded_field()` (was `cache_*`/`has_cache`), and the `Replayable` concept.
+> Follow-ups live in the odelia tracker: **#22** (interpolator unification), **#23**
+> (history rows), **#27** (functional = pure reduction; driver owns the replay), **#28**
+> (pare the demonstrator, retire `live|frozen`), **#25/#26** (comments, tests).
+
 ### ODELIA-1 — Generalize `compute_gradient` to an arbitrary functional · CP
 Replace the hard-coded `sum_of_squares` with a caller-supplied functional
-`std::vector<S> f(const System& solved)`. Keep `sum_of_squares`/`advance_target` as
-a prebuilt instance. **Depends on:** —. **Blocks:** ODELIA-2, PLANT-4.
+`std::vector<S> f(const System& replayed)`. Keep `sum_of_squares` as the prebuilt
+`least_squares` functional instance. **Depends on:** —. **Blocks:** ODELIA-2, PLANT-4.
 
 ### ODELIA-2 — `compute_jacobian` (reverse, row-sweep) · CP
 Record once, one adjoint sweep per output row (adjoint `XAD::computeJacobian`
 pattern), reusing the Solver-owned tape. **Depends on:** ODELIA-1. **Blocks:**
 PLANT-4, UX-1.
 
-### ODELIA-3 — `Independents` + `AnalyticEdge` · CP
-The "differentiate w.r.t. what" bundle (renamed from `Seeds`) and the analytic-edge
-injection built on `CheckpointCallback`. **Depends on:** PROTO-3. **Blocks:**
+### ODELIA-3 — `DifferentiationTargets` + `SuppliedDerivative` · CP
+The "differentiate w.r.t. what" bundle (`DifferentiationTargets`) and the
+`SuppliedDerivative` injection built on `CheckpointCallback`. **Depends on:** PROTO-3. **Blocks:**
 PLANT-2 (traits), PLANT-6 (leaf edge).
 
 ### ODELIA-4 — odelia-native test harness for the AD surface · CP-support
@@ -57,11 +66,11 @@ are release-gating):
 - **`compute_gradient` / `compute_jacobian`** — value + gradient against finite
   differences on a closed-form system; Jacobian shape/row-sweep on a multi-output
   functional; tape reuse across repeated calls. **Depends on:** ODELIA-1, ODELIA-2.
-- **`AnalyticEdge` (ODELIA-4b)** — an off-tape root-find whose IFT edge is injected
+- **`SuppliedDerivative` (ODELIA-4b)** — an off-tape root-find whose IFT edge is injected
   via `CheckpointCallback`, checked against the analytic derivative and against
   differentiating the solve directly. **Depends on:** ODELIA-3.
 - **Functional shape (ODELIA-4b)** — a custom functional (not `sum_of_squares`) plus
-  the `sum_of_squares`/`advance_target` instance, to prove the seam is functional-
+  the `least_squares` functional instance, to prove the seam is functional-
   agnostic. **Depends on:** ODELIA-1.
 - **Record/replay-fixed (ODELIA-4a)** — a system with an adaptive interpolator and a
   quadrature: assert the fixed-node replay reproduces the adaptive run's value and
@@ -72,18 +81,21 @@ AD-vs-AD oracle (UX-2) still gates the plant ports separately.
 
 ### ODELIA-5 — Document the AD API contract in `ARCHITECTURE.md` · CP-support
 Extend the existing Tape-linking contract to cover the AD *API* (functional shape,
-`Independents`, edges) so plant depends on a versioned odelia surface. **Depends
+`DifferentiationTargets`, supplied derivatives) so plant depends on a versioned odelia surface. **Depends
 on:** ODELIA-1..3.
 
 ### ODELIA-6 — Record-adaptive / replay-fixed numerics (the one replay primitive) · CP
 Make odelia's adaptive numerics support "record node placement on the double pass,
-replay on fixed nodes with the active scalar" uniformly (design §7.5–7.6). Two
-mechanisms, both partly present:
-- **Record via opt-in System hooks.** The stepper already calls `cache_RK45_step` /
-  `cache_ode_step` when a System provides them (`has_cache` trait; zero-cost no-op
-  otherwise). Reuse these hook points; shrink the payload to knot positions (not
-  `stand_stage_history`). Express any *new* hooks with C++20 concepts + `if
-  constexpr` rather than more `enable_if` SFINAE (design §7.6).
+replay on fixed nodes with the active scalar" uniformly (design §7.5–7.6). **Detailed
+design: [`ad-record-replay.md`](./ad-record-replay.md)** — positions-vs-values, one
+`Replayable` concept (runtime frozen/live mode, not a type split), no `Recording` noun,
+and the RIF-3 anchor settled on the `Solver` member. Two mechanisms, both partly
+present:
+- **Record via opt-in System hooks.** The stepper calls `record_stage` /
+  `record_ode_step` / `replay_step` when a System provides them (the `Replayable`
+  concept, C++20 `requires` + `if constexpr`; zero-cost no-op otherwise). The payload
+  is knot positions (per step) and frozen field values (per stage), not
+  `stand_stage_history`.
 - **Replay-fixed components.** `advance_fixed` (stepper) and `basic_interpolator<S>`
   (frozen knots, active values) exist; the **gap** is a scalar-templated fixed-rule
   `QK<S>` that consumes a recorded QAG subdivision — or a prototype showing a single
@@ -134,7 +146,7 @@ through the *moving* quadrature nodes; reconstruct the resident light on odelia'
 frozen-knot differentiable spline (design §7, L2). This is the level a frozen-node
 replay misses. **Depends on:** PLANT-5. **Blocks:** census gradients (UX-3 metrics).
 
-### PLANT-6 — Leaf-optimizer `AnalyticEdge` for TF24/TF24f · CP
+### PLANT-6 — Leaf-optimizer `SuppliedDerivative` for TF24/TF24f · CP
 Route the forward-mode leaf sensitivity through the odelia edge. **Depends on:**
 ODELIA-3, PROTO-2. **Blocks:** PLANT-7 (TF24/TF24f).
 
@@ -206,8 +218,9 @@ Removes the type-confusion hazard in `Solver_fit_impl`.
 A System contract so the driver constructs the active system generically instead of
 per-example hand-construction. **Depends on:** —. **Blocks:** RIF-1.
 
-### RIF-3 — odelia opaque tape/active-scratch cache on the double Solver · CP-support
-Tape reuse within a Jacobian and across optimizer calls, without R seeing it.
+### RIF-3 — odelia tape/active-solver cache on the double Solver · CP-support
+Tape reuse within a Jacobian and across optimizer calls, without R seeing it. The
+cached active solver is typed via the System's `rebind` (no `void*`/`static_cast`).
 **Depends on:** RIF-1.
 
 ### RIF-4 — odelia policy: no `wrap`/`as` for active types · NTH

--- a/notes/ad-design/ad-r-interface.md
+++ b/notes/ad-design/ad-r-interface.md
@@ -1,0 +1,346 @@
+# AD infrastructure: the R boundary for plant and odelia
+
+Companion to [`ad-infrastructure-design.md`](./ad-infrastructure-design.md) and
+[`ad-issues.md`](./ad-issues.md). This document covers how AD crosses the R/C++
+boundary — the part Rcpp and RcppR6 make awkward — and the interface design that
+keeps it clean.
+
+---
+
+## 1. The problem
+
+Rcpp's `as<>`/`wrap<>` and RcppR6's generated bindings marshal **`double`** (and
+containers of it). An XAD active type (`xad::adj<double>::active_type`) is a
+different scalar with a tape identity; it has **no `as`/`wrap`** and must never
+acquire one — serialising it would silently drop the derivative. Three concrete
+frictions follow:
+
+1. **Distinct pointer types, hand-dispatched.** `Solver<System<double>>` and
+   `Solver<System<active>>` are unrelated C++ types, so they are two different
+   `Rcpp::XPtr`s. odelia dispatches between them with a `bool active` flag
+   threaded through *every* export (`if (active) get_solver<ActiveSystemType>` …;
+   `Solver_reset_impl<SystemType, ActiveSystemType>`). The flag and the pointer's
+   real type are kept in sync **only by convention** — `Solver_fit_impl` reads the
+   handle as `<ActiveSystemType>` unconditionally, so a double handle reaches it as
+   a type-confused reinterpret (UB / crash), not an error.
+2. **Two objects leak into R.** To *fit*, the odelia user must construct a
+   *second*, active solver (`LeafSolver_new(active = true)`) alongside the double
+   one used to simulate. The active/double split becomes the R user's problem.
+3. **The plant round-trip.** RcppR6 marshals a `FF16_Environment` to/from an R
+   list. The spike's early replay rebuilt each per-stage environment in C++ with
+   `Rcpp::as<plant::FF16_Environment>(st[k])` — a serialisation round-trip that is
+   lossy for crown-sampled light and rebuilds the whole object per access
+   (O(stand), ~1600× slower).
+
+---
+
+## 2. The invariant
+
+> **Only `double` crosses the R boundary. Active types are created, used, and
+> destroyed entirely within a single C++ call. R never holds an active handle.**
+
+Everything below follows from this one rule. The AD lifecycle (build active
+system → seed inputs → record → run → back-propagate → read adjoints) is an
+internal detail of one C++ function; its inputs are doubles (and object handles)
+and its outputs are doubles. The only place an active value is read is
+`xad::value(x)` / `xad::derivative(x)` → `double`, at the very end.
+
+This is not a limitation to work around — it is the design. It removes the pointer
+duplication, the `active` flag, and the round-trip all at once, because none of
+them need to exist if active types never travel.
+
+---
+
+## 3. odelia R interface
+
+### 3.1 Retire the R-visible active solver and the `active` flag
+
+R holds only the **double** `Solver`. Gradients are a driver call that builds the
+active replay internally:
+
+```cpp
+// [[Rcpp::export]]  — R passes the DOUBLE solver handle; only doubles return.
+Rcpp::List Solver_gradient(SEXP solver_xp,
+                           Rcpp::Nullable<Rcpp::NumericVector> ic,
+                           Rcpp::Nullable<Rcpp::NumericVector> params) {
+  auto solver = get_solver<SystemType>(solver_xp);          // the DOUBLE solver
+  auto [value, grad] = ode::compute_gradient(*solver, independents(ic, params),
+                                             sum_of_squares_functional);
+  return Rcpp::List::create(_["value"] = value, _["gradient"] = wrap(grad));
+}
+```
+
+`compute_gradient`/`compute_jacobian` own the active system for the duration of
+the call. The `bool active` parameter, the `ActiveSystemType` XPtr, and the dual
+`_impl<SystemType, ActiveSystemType>` signatures disappear from the R surface. The
+type-confusion hazard is gone because there is only one handle type.
+
+### 3.2 A `rebind` contract so the driver can lift double → active
+
+Today `LeafSolver_new` constructs the active system by hand
+(`ActiveSystemType sys_active(pars, drv); sys_active.set_initial_state(…)`). Give
+the System a single lift so the driver does this generically:
+
+```cpp
+struct System {
+  using value_type = S;
+  template <class S2> using rebind = System<…, S2>;   // double -> active mould
+  template <class S2> System<…,S2> rebind_from() const; // copy config into S2
+};
+```
+
+The driver calls `rebind_from<active>()`, seeds via the existing `set_params` /
+`set_initial_state`, runs, and reads adjoints — all internal.
+
+### 3.3 Tape reuse without exposing active types
+
+The persistent tape matters *within* a call (a Jacobian records once and sweeps
+per row) and across calls (an optimizer loop calling `Solver_gradient` repeatedly).
+Keep it internal: cache the tape (and optionally the active scratch system) as an
+**opaque handle owned by the double Solver**, keyed to nothing R can see. R reuses
+the tape by reusing its double Solver; it never learns the tape exists.
+
+### 3.4 No `wrap`/`as` for active types — by policy
+
+Do **not** add an `Rcpp::wrap`/`Rcpp::as` specialization for XAD active types.
+Forcing an explicit `xad::value()` / `xad::derivative()` at the one extraction
+point keeps derivative loss visible and impossible to do by accident.
+
+---
+
+## 4. plant R interface
+
+### 4.1 Pass the RcppR6 handle; unwrap the pointer, don't serialise
+
+plant's SCM/Patch are RcppR6 objects over the **double** `<T,E>` types; keep them
+that way. Gradient entries are hand-written `[[Rcpp::export]]` functions that take
+the RcppR6 SCM and unwrap only its pointer — the pattern the spike's best entry
+already uses:
+
+```cpp
+// [[Rcpp::export]]
+Rcpp::NumericMatrix stand_gradient_cpp(SEXP scm_sexp, /* metric names, traits, … */) {
+  // Rcpp::as<RcppR6<…>> unwraps .ptr only — NO serialisation of the SCM.
+  auto scm = Rcpp::as<plant::RcppR6::RcppR6<plant::SCM<FF16, FF16_Environment>>>(scm_sexp);
+  // build the active replay from the LIVE patch (native pointers into
+  // environment_history / step_history) — no Rcpp::as<FF16_Environment>.
+  // call odelia::compute_jacobian with an EmergentFunctional; return doubles.
+}
+```
+
+### 4.2 Native harvest — delete the `Rcpp::as<Environment>` round-trip
+
+The active replay reads the resident schedule and per-stage environments **by
+pointer into the live Patch's own storage** (issue PLANT-4/5), so the round-trip of
+§1.3 never happens. The environment is only ever read as a `double` value plus an
+analytic/AD contribution; the active type never touches an RcppR6 object.
+
+### 4.3 One thin R wrapper over one C++ entry
+
+`stand_gradient()` keeps its signature (`scm, metrics, traits, species, feedback`)
+but stops branching in R across `native` / `impl` / resident variants. It forwards
+to a single C++ entry that dispatches strategy and feedback **in C++** (where the
+active types live), returning the double Jacobian + values. RcppR6 never sees an
+active type; the emergent translation unit is the only place they exist.
+
+### 4.4 Functionals are constructed in C++, not passed from R
+
+R cannot pass a C++ functional. R passes the **metric names** (strings); plant's
+C++ entry maps them to an `EmergentFunctional` (a compile-time object reusing the
+scalar-templated reductions) and hands that to odelia's driver. The "functional
+shape" is a C++ concept that never crosses to R — only its *selection* does.
+
+---
+
+## 5. Resulting UX
+
+- **odelia:** one solver object; `solver$gradient(params = …)` returns
+  `list(value, gradient)`. No `active =` flag, no second solver, no way to hold a
+  handle of the wrong type.
+- **plant:** `stand_gradient(scm, metrics, traits, species, feedback)` on the
+  ordinary (double) SCM the user already ran; returns a double Jacobian. No AD
+  objects, no cache marshalling, no round-trip. The replay levels (design §7) are
+  internal: the user runs the resident once with the caching their gradient needs,
+  and the call selects L0–L3 accordingly.
+
+### 5.1 What the user must run (replay levels, design §7)
+
+The levels are internal, but they determine the *one* thing the user sets on the
+resident run:
+
+| Priority | Gradient | User runs | Levels | Canopy |
+|---|---|---|---|---|
+| primary | census resident (LAI, biomass, basal area) | `control(save_RK45_cache = TRUE)` | L0·L1·L2·L3 | reconstructed (active) |
+| next | offspring / invasion | `control(save_RK45_cache = TRUE)` | L0·L1·L3 | frozen |
+| advanced | ODE calibration | adaptive run, then fit — no cache; needs observations + loss | L1 | n/a |
+
+`save_RK45_cache = TRUE` is the single AD-relevant control for the emergent
+workflows. It records what the replay needs (design §7.5): the resolved ODE step
+times, and the adaptive light-spline knot positions / quadrature nodes. The invasion
+gradient reuses the recorded resident light frozen; the resident gradient re-runs
+`compute_environment` on the recorded knots with active cohorts (no stand-state
+cache). A gradient call validates the recording is present and errors clearly if not
+(§6.7) — it never silently returns a wrong number. (If the flag name should read as
+"prepare for gradients" rather than an implementation detail, that is a small rename
+to settle during RIF-7.)
+
+The calibration row is deliberately last: it additionally requires the user to
+supply observations and a likelihood, which the emergent workflows do not.
+Calibrating the *plant SCM* to data is not a different replay — it is the **resident
+replay (L0·L1·L2) plus a likelihood functional**, an addition over the emergent
+resident gradient, not a subtraction. The `L1`-only row above is the bare-ODE
+(odelia Lorenz) degenerate case; its `set_target`/`advance_target` fit shape
+(`test-ad-workflow.R`) serves that case and must **not** set the shape of the primary
+`stand_gradient()` UX.
+
+---
+
+## 6. User stories
+
+Each story is the R experience of one persona. The recurring point is what they
+*never* touch — the invariant of §2 paying off. The last line of each traces to the
+design and surfaces any requirement. Stories are ordered by priority: the emergent
+gradients (6.1 resident, 6.2 invasion) are the **primary** plant workflows and need
+no observations; calibration (6.3) is an **advanced** case that additionally assumes
+targets and a likelihood, and is included to test the invariant under a hot loop —
+not as the entry point.
+
+### 6.1 Trait sensitivity — forest ecologist (plant, resident/total)
+
+*"I have a calibrated FF16 stand; how do emergent LAI and biomass respond to leaf
+mass per area and wood density?"*
+
+```r
+scm <- run_scm(params, control = control(save_RK45_cache = TRUE))
+g   <- stand_gradient(scm, metrics = c("LAI", "biomass"),
+                      traits = c("lma", "rho"), feedback = "resident")
+g$jacobian     # 2x2 doubles: d(metric)/d(trait), with self-shading feedback
+```
+
+Never touches XAD, an active type, a tape, or a second solver. The only AD-aware
+line is `save_RK45_cache = TRUE`, which belongs to the model run. *Traces to §4,
+§5; requires the native harvest (RIF-6) and C++ functional-by-name (§4.4).*
+
+### 6.2 Selection gradient — evolutionary ecologist (plant, mutant/invasion)
+
+*"Give me the invasion-fitness gradient of a rare mutant against an established
+resident, so I can locate singular strategies."*
+
+```r
+resident <- run_scm(resident_params, control = control(save_RK45_cache = TRUE))
+sel <- offspring_production_gradient(resident, traits = c("lma", "hmat"))
+# named double vector: d(fitness)/d(trait), resident canopy held frozen
+```
+
+The frozen canopy and the `run_mutant` replay are entirely under the hood; the user
+picks the workflow by choosing the function, not by managing state. *Traces to the
+two-workflow model (design §6.1) and §4.3 (C++ dispatch).*
+
+### 6.3 Gradient-based calibration — modeller fitting data (the hot loop) — *advanced*
+
+*"Run L-BFGS over traits to fit observations; call me for value and gradient each
+iteration."* (Advanced: unlike 6.1/6.2 this assumes the user has defined
+observations and a likelihood.)
+
+```r
+solver <- Solver$new(system, control)     # ONE ordinary (double) solver
+solver$set_target(times, obs, obs_idx)
+optim(par,
+      fn = \(p) solver$value_and_gradient(p)$value,     # doubles in/out
+      gr = \(p) solver$value_and_gradient(p)$gradient,
+      method = "L-BFGS-B")
+```
+
+This is the **L1** replay (design §7): an adaptive run captures the ODE step
+schedule, then AD replays pinned to it — no environment cache. It is the story that
+most stresses the invariant — a tight loop that would be the natural place to "cache
+the active solver in R." It does not: the tape is reused through the opaque cache on
+the double solver (§3.3), and the user never sees an active handle or an `active =`
+flag. **Requirement surfaced:** expose a single `value_and_gradient(p)` that returns
+both from **one** recording, so `fn`/`gr` don't each re-run the tape (a pure
+`gradient()` and `loss()` would double the work in an optimizer). *Traces to
+§3.1/§3.3, RIF-1/RIF-3; adds `value_and_gradient` to RIF-1.*
+
+### 6.4 A new emergent metric — plant developer
+
+The shipped metrics are **LAI, biomass, and basal area** (plus
+`offspring_production`). Extensibility is the story: a developer adds "mean canopy
+height" (a tutorial-level example) with one scalar-templated kernel that reuses
+existing model functions and registers its name. Then:
+
+```r
+stand_gradient(scm, metrics = "mean_height", traits = ff16_default_traits())
+```
+
+works immediately — the C++ entry maps the name to the functional; the reverse
+sweep is odelia's. No tape code, no odelia change. *Traces to §4.4 and design §5;
+confirms "adding a metric is one kernel." mean-height lives in a tutorial, not the
+shipped set.*
+
+### 6.5 A new ODE model — odelia downstream developer
+
+*"I'm building a hydraulics module on odelia; I want gradients without writing
+marshalling or tape code."*
+
+The developer implements the System contract — `value_type`, `set_params`,
+`set_initial_state`, and `rebind` (§3.2) — and gets `Solver_gradient` /
+`Solver_jacobian` for free, doubles only. odelia never learns what a hydraulic
+segment is. *Traces to §3.2; validates the plant-agnostic odelia surface.*
+
+### 6.6 Trusting a gradient — maintainer (verification)
+
+*"Check the AD gradient against a finite difference before I rely on it."*
+
+```r
+g_ad <- stand_gradient(scm, "offspring_production", "lma")$jacobian
+g_fd <- (op_at(lma + h) - op_at(lma - h)) / (2 * h)   # re-run scm, perturbed lma
+stopifnot(abs(g_ad - g_fd) < tol)
+```
+
+Because the AD path returns doubles in the same shape as the finite-difference path,
+verification is a plain numeric comparison. *Traces to the doubles-only boundary and
+the regression oracle (UX-2).*
+
+### 6.7 Edge case — forgot the cache (fail loud, never confuse)
+
+*"I ran the SCM without `save_RK45_cache` and asked for a gradient."*
+
+```r
+scm <- run_scm(params)                 # no cache
+stand_gradient(scm, "LAI", "lma")
+#> Error: no resident schedule cached; re-run with control(save_RK45_cache = TRUE)
+```
+
+A clear, actionable error — never a crash. This is the deliberate contrast with the
+§1.1 hazard: with active types off the R surface there is no wrong-typed handle to
+reinterpret, so the boundary can only fail loudly. *Traces to §2, §3.1.*
+
+---
+
+## 7. Work items (feed `ad-issues.md`)
+
+| Item | Repo | Class | Note |
+|---|---|---|---|
+| RIF-1 | odelia | CP | `Solver_gradient`/`Solver_jacobian`/`value_and_gradient` on the double handle; retire the `active` flag + `ActiveSystemType` XPtr from the R surface |
+| RIF-2 | odelia | CP | `rebind` lift contract (§3.2) so the driver constructs the active system |
+| RIF-3 | odelia | CP-support | opaque tape/active-scratch cache on the double Solver (§3.3) |
+| RIF-4 | odelia | NTH | policy check: ensure no `wrap`/`as` for active types compiles |
+| RIF-5 | plant | CP | single `stand_gradient_cpp` entry taking the RcppR6 handle; C++ strategy/feedback dispatch (§4.1, §4.3) |
+| RIF-6 | plant | CP | native-pointer harvest; delete `Rcpp::as<*_Environment>` (ties to PLANT-4/5) |
+| RIF-7 | plant | CP-support | thin `stand_gradient()` R wrapper; remove R-side branching |
+
+**Dependencies:** RIF-1..3 sit under ODELIA-1/2/3 (they are the R-facing side of the
+driver). RIF-5..7 sit under PLANT-4/5 (native harvest) and UX-1 (stable surface).
+None require exposing an active type to R; that is the point.
+
+## Open questions
+
+- **Keep any R-visible active solver at all?** An advanced user driving a bespoke
+  optimizer loop in R might want to hold AD state across calls. The opaque-cache
+  approach (§3.3) covers the common case; decide whether a power-user escape hatch
+  is worth the re-introduced footgun. Recommendation: no — start with the invariant,
+  add an escape hatch only on a demonstrated need.
+- **RcppR6 template-type dispatch.** `stand_gradient_cpp` must resolve the SCM's
+  `<T,E>` (FF16 / TF24 / TF24f) to instantiate the right replay. Confirm whether
+  this dispatch is best done by the existing `extract_RcppR6_template_types` (R
+  side, strings) feeding a C++ `switch`, or a C++-side type tag on the handle.

--- a/notes/ad-design/ad-r-interface.md
+++ b/notes/ad-design/ad-r-interface.md
@@ -1,62 +1,53 @@
 # AD infrastructure: the R boundary for plant and odelia
 
-Companion to [`ad-infrastructure-design.md`](./ad-infrastructure-design.md) and
-[`ad-issues.md`](./ad-issues.md). This document covers how AD crosses the R/C++
-boundary — the part Rcpp and RcppR6 make awkward — and the interface design that
-keeps it clean.
+Companion to [`ad-infrastructure-design.md`](./ad-infrastructure-design.md). This
+document covers how AD crosses the R/C++ boundary — the part Rcpp and RcppR6 make
+awkward — and the interface design that keeps it clean.
 
 ---
 
 ## 1. The problem
 
-Rcpp's `as<>`/`wrap<>` and RcppR6's generated bindings marshal **`double`** (and
-containers of it). An XAD active type (`xad::adj<double>::active_type`) is a
-different scalar with a tape identity; it has **no `as`/`wrap`** and must never
-acquire one — serialising it would silently drop the derivative. Three concrete
-frictions follow:
+Rcpp's `as<>`/`wrap<>` and RcppR6's bindings marshal **`double`** and containers of it.
+An XAD active type (`xad::adj<double>::active_type`) is a different scalar with a tape
+identity; it has **no `as`/`wrap`** and must never acquire one — serialising it would
+silently drop the derivative. Three frictions follow, and the invariant of §2 removes all
+three at once:
 
-1. **Distinct pointer types, hand-dispatched.** `Solver<System<double>>` and
-   `Solver<System<active>>` are unrelated C++ types, so they are two different
-   `Rcpp::XPtr`s. odelia dispatches between them with a `bool active` flag
-   threaded through *every* export (`if (active) get_solver<ActiveSystemType>` …;
-   `Solver_reset_impl<SystemType, ActiveSystemType>`). The flag and the pointer's
-   real type are kept in sync **only by convention** — `Solver_fit_impl` reads the
-   handle as `<ActiveSystemType>` unconditionally, so a double handle reaches it as
-   a type-confused reinterpret (UB / crash), not an error.
-2. **Two objects leak into R.** To *fit*, the odelia user must construct a
-   *second*, active solver (`LeafSolver_new(active = true)`) alongside the double
-   one used to simulate. The active/double split becomes the R user's problem.
-3. **The plant round-trip.** RcppR6 marshals a `FF16_Environment` to/from an R
-   list. The spike's early replay rebuilt each per-stage environment in C++ with
-   `Rcpp::as<plant::FF16_Environment>(st[k])` — a serialisation round-trip that is
-   lossy for crown-sampled light and rebuilds the whole object per access
-   (O(stand), ~1600× slower).
+1. **Two pointer types.** `Solver<System<double>>` and `Solver<System<active>>` are
+   unrelated C++ types, so a binding that exposes both needs a flag to dispatch between
+   them — and the flag and the pointer's real type stay in sync only by convention, a
+   type-confusion footgun.
+2. **Two objects in R.** Exposing the active solver forces the user to build and hold a
+   *second* solver alongside the double one they simulate with.
+3. **The plant round-trip.** Marshalling a `FF16_Environment` to/from an R list to
+   rebuild each per-stage environment is lossy for crown-sampled light and rebuilds the
+   whole object per access — O(stand), orders of magnitude slower than a native-pointer
+   read.
 
 ---
 
 ## 2. The invariant
 
-> **Only `double` crosses the R boundary. Active types are created, used, and
-> destroyed entirely within a single C++ call. R never holds an active handle.**
+> **Only `double` crosses the R boundary. Active types are created, used, and destroyed
+> entirely within a single C++ call. R never holds an active handle.**
 
-Everything below follows from this one rule. The AD lifecycle (build active
-system → seed inputs → record → run → back-propagate → read adjoints) is an
-internal detail of one C++ function; its inputs are doubles (and object handles)
-and its outputs are doubles. The only place an active value is read is
-`xad::value(x)` / `xad::derivative(x)` → `double`, at the very end.
+Everything below follows from this one rule. The AD lifecycle — build the active system,
+seed inputs, record, run, back-propagate, read adjoints — is an internal detail of one
+C++ function; its inputs are doubles (and object handles) and its outputs are doubles. The
+only place an active value is read is `xad::value(x)` / `xad::derivative(x)` → `double`, at
+the very end.
 
-This is not a limitation to work around — it is the design. It removes the pointer
-duplication, the `active` flag, and the round-trip all at once, because none of
-them need to exist if active types never travel.
+This is the design, not a limitation worked around: the pointer duplication, the `active`
+flag, and the round-trip do not need to exist if active types never travel.
 
 ---
 
 ## 3. odelia R interface
 
-### 3.1 Retire the R-visible active solver and the `active` flag
+### 3.1 R holds only the double Solver
 
-R holds only the **double** `Solver`. Gradients are a driver call that builds the
-active replay internally:
+A gradient is a driver call that builds the active solver internally:
 
 ```cpp
 // [[Rcpp::export]]  — R passes the DOUBLE solver handle; only doubles return.
@@ -64,47 +55,63 @@ Rcpp::List Solver_gradient(SEXP solver_xp,
                            Rcpp::Nullable<Rcpp::NumericVector> ic,
                            Rcpp::Nullable<Rcpp::NumericVector> params) {
   auto solver = get_solver<SystemType>(solver_xp);          // the DOUBLE solver
-  auto [value, grad] = ode::compute_gradient(*solver, independents(ic, params),
-                                             sum_of_squares_functional);
+  auto [value, grad] = ode::compute_gradient(*solver, differentiation_targets(ic, params),
+                                             emergent_functional);
   return Rcpp::List::create(_["value"] = value, _["gradient"] = wrap(grad));
 }
 ```
 
-`compute_gradient`/`compute_jacobian` own the active system for the duration of
-the call. The `bool active` parameter, the `ActiveSystemType` XPtr, and the dual
-`_impl<SystemType, ActiveSystemType>` signatures disappear from the R surface. The
-type-confusion hazard is gone because there is only one handle type.
+`compute_gradient` / `compute_jacobian` own the active system for the duration of the
+call. There is one handle type, so a gradient call cannot reinterpret a double handle as
+active — the boundary can only fail loudly.
 
-### 3.2 A `rebind` contract so the driver can lift double → active
+### 3.2 A `rebind` contract so the driver lifts double → active
 
-Today `LeafSolver_new` constructs the active system by hand
-(`ActiveSystemType sys_active(pars, drv); sys_active.set_initial_state(…)`). Give
-the System a single lift so the driver does this generically:
+The System carries a single lift so the driver builds the active system generically:
 
 ```cpp
 struct System {
   using value_type = S;
-  template <class S2> using rebind = System<…, S2>;   // double -> active mould
+  template <class S2> using rebind = System<…, S2>;     // double -> active mould
   template <class S2> System<…,S2> rebind_from() const; // copy config into S2
 };
 ```
 
 The driver calls `rebind_from<active>()`, seeds via the existing `set_params` /
-`set_initial_state`, runs, and reads adjoints — all internal.
+`set_initial_state`, runs, and reads adjoints — all internal. Only values cross in the
+lift, so the active system starts free of tape identity.
 
 ### 3.3 Tape reuse without exposing active types
 
-The persistent tape matters *within* a call (a Jacobian records once and sweeps
-per row) and across calls (an optimizer loop calling `Solver_gradient` repeatedly).
-Keep it internal: cache the tape (and optionally the active scratch system) as an
-**opaque handle owned by the double Solver**, keyed to nothing R can see. R reuses
-the tape by reusing its double Solver; it never learns the tape exists.
+The persistent tape matters *within* a call (a Jacobian records once and sweeps per row)
+and *across* calls (an optimizer loop calling `Solver_gradient` repeatedly). It stays
+internal: the active solver is cached on the double Solver, and R reuses it by reusing its
+double Solver, never learning the tape exists. Three facts:
+
+- **The active solver is the only cached thing.** The gradient runs on it, and a `Solver`
+  carries its own `tape`, so that tape *is* the reused tape — there is nothing else to
+  cache. It is held on the double Solver, and its type is **named, not erased**: the
+  System supplies `rebind`, so `System::rebind<active>` spells it from inside
+  `Solver<System>` — no `void*`, no `static_cast`.
+- **Anchored on the `Solver` object, not an R handle.** plant's SCM holds the solver as a
+  plain C++ member (`scm.h`: `Solver<patch_type> solver;`) and never wraps it in an XPtr,
+  so a handle-slot anchor would be invisible to it. Anchoring on the `Solver` object gives
+  `stand_gradient_cpp` the reuse for free.
+- **The recording is read per call, not frozen into the active solver.** The recording —
+  resolved step times and any interpolator/quadrature spacing or frozen field values (the
+  replay levels of design §7) — is per-run state owned by the immutable double Solver and
+  handed over on every call. Its validity domain is the ICs and params of the double run:
+  a replay may vary the mutant / observations / functional, but changing ICs or params
+  invalidates the recording and forces a re-record.
+
+Two senses of "cache" stay distinct: the active solver + tape is a **speed** cache; the
+record/replay recording is **semantic**. Reusing the cache never changes a number.
 
 ### 3.4 No `wrap`/`as` for active types — by policy
 
-Do **not** add an `Rcpp::wrap`/`Rcpp::as` specialization for XAD active types.
-Forcing an explicit `xad::value()` / `xad::derivative()` at the one extraction
-point keeps derivative loss visible and impossible to do by accident.
+Do **not** add an `Rcpp::wrap` / `Rcpp::as` specialization for active types. Forcing an
+explicit `xad::value()` / `xad::derivative()` at the one extraction point keeps derivative
+loss visible and impossible to do by accident.
 
 ---
 
@@ -112,10 +119,9 @@ point keeps derivative loss visible and impossible to do by accident.
 
 ### 4.1 Pass the RcppR6 handle; unwrap the pointer, don't serialise
 
-plant's SCM/Patch are RcppR6 objects over the **double** `<T,E>` types; keep them
-that way. Gradient entries are hand-written `[[Rcpp::export]]` functions that take
-the RcppR6 SCM and unwrap only its pointer — the pattern the spike's best entry
-already uses:
+plant's SCM/Patch are RcppR6 objects over the **double** `<T,E>` types; they stay that
+way. Gradient entries are hand-written `[[Rcpp::export]]` functions that take the RcppR6
+SCM and unwrap only its pointer:
 
 ```cpp
 // [[Rcpp::export]]
@@ -128,87 +134,74 @@ Rcpp::NumericMatrix stand_gradient_cpp(SEXP scm_sexp, /* metric names, traits, �
 }
 ```
 
-### 4.2 Native harvest — delete the `Rcpp::as<Environment>` round-trip
+### 4.2 Native harvest — no `Rcpp::as<Environment>` round-trip
 
-The active replay reads the resident schedule and per-stage environments **by
-pointer into the live Patch's own storage** (issue PLANT-4/5), so the round-trip of
-§1.3 never happens. The environment is only ever read as a `double` value plus an
-analytic/AD contribution; the active type never touches an RcppR6 object.
+The active replay reads the resident schedule and per-stage environments **by pointer into
+the live Patch's own storage**, so the round-trip of §1 never happens. The environment is
+only ever read as a `double` value plus an analytic/AD contribution; the active type never
+touches an RcppR6 object.
 
 ### 4.3 One thin R wrapper over one C++ entry
 
-`stand_gradient()` keeps its signature (`scm, metrics, traits, species, feedback`)
-but stops branching in R across `native` / `impl` / resident variants. It forwards
-to a single C++ entry that dispatches strategy and feedback **in C++** (where the
-active types live), returning the double Jacobian + values. RcppR6 never sees an
-active type; the emergent translation unit is the only place they exist.
+`stand_gradient()` keeps its signature (`scm, metrics, traits, species, feedback`) and
+forwards to a single C++ entry that dispatches strategy and feedback **in C++**, where the
+active types live, returning the double Jacobian and values. RcppR6 never sees an active
+type; the emergent translation unit is the only place they exist.
 
 ### 4.4 Functionals are constructed in C++, not passed from R
 
-R cannot pass a C++ functional. R passes the **metric names** (strings); plant's
-C++ entry maps them to an `EmergentFunctional` (a compile-time object reusing the
-scalar-templated reductions) and hands that to odelia's driver. The "functional
-shape" is a C++ concept that never crosses to R — only its *selection* does.
+R cannot pass a C++ functional. R passes the **metric names** (strings); plant's C++ entry
+maps them to an `EmergentFunctional` (a compile-time object reusing the scalar-templated
+reductions) and hands that to odelia's driver. The functional shape never crosses to R —
+only its *selection* does.
 
 ---
 
 ## 5. Resulting UX
 
-- **odelia:** one solver object; `solver$gradient(params = …)` returns
-  `list(value, gradient)`. No `active =` flag, no second solver, no way to hold a
-  handle of the wrong type.
-- **plant:** `stand_gradient(scm, metrics, traits, species, feedback)` on the
-  ordinary (double) SCM the user already ran; returns a double Jacobian. No AD
-  objects, no cache marshalling, no round-trip. The replay levels (design §7) are
-  internal: the user runs the resident once with the caching their gradient needs,
-  and the call selects L0–L3 accordingly.
+- **odelia:** one solver object; `solver$gradient(params = …)` returns `list(value,
+  gradient)`. No `active =` flag, no second solver, no way to hold a handle of the wrong
+  type.
+- **plant:** `stand_gradient(scm, metrics, traits, species, feedback)` on the ordinary
+  (double) SCM the user already ran; returns a double Jacobian. No AD objects, no cache
+  marshalling, no round-trip. The replay levels are internal.
 
-### 5.1 What the user must run (replay levels, design §7)
+### 5.1 What the user sets on the resident run
 
-The levels are internal, but they determine the *one* thing the user sets on the
-resident run:
+The replay levels are internal, but they determine the one thing the user sets:
 
 | Priority | Gradient | User runs | Levels | Canopy |
 |---|---|---|---|---|
 | primary | census resident (LAI, biomass, basal area) | `control(save_RK45_cache = TRUE)` | L0·L1·L2·L3 | reconstructed (active) |
 | next | offspring / invasion | `control(save_RK45_cache = TRUE)` | L0·L1·L3 | frozen |
-| advanced | ODE calibration | adaptive run, then fit — no cache; needs observations + loss | L1 | n/a |
+| advanced | ODE calibration | adaptive run, then fit (needs observations + likelihood) | L1 | n/a |
 
-`save_RK45_cache = TRUE` is the single AD-relevant control for the emergent
-workflows. It records what the replay needs (design §7.5): the resolved ODE step
-times, and the adaptive light-spline knot positions / quadrature nodes. The invasion
-gradient reuses the recorded resident light frozen; the resident gradient re-runs
-`compute_environment` on the recorded knots with active cohorts (no stand-state
-cache). A gradient call validates the recording is present and errors clearly if not
-(§6.7) — it never silently returns a wrong number. (If the flag name should read as
-"prepare for gradients" rather than an implementation detail, that is a small rename
-to settle during RIF-7.)
+`save_RK45_cache = TRUE` is the single AD-relevant control for the emergent workflows. It
+records what the replay needs: the resolved ODE step times and the adaptive light-spline
+knot positions / quadrature nodes. The invasion gradient reuses the recorded resident
+light frozen; the resident gradient re-runs `compute_environment` on the recorded knots
+with active cohorts. A gradient call validates the recording is present and errors clearly
+if not (§6.7) — it never silently returns a wrong number.
 
-The calibration row is deliberately last: it additionally requires the user to
-supply observations and a likelihood, which the emergent workflows do not.
-Calibrating the *plant SCM* to data is not a different replay — it is the **resident
-replay (L0·L1·L2) plus a likelihood functional**, an addition over the emergent
-resident gradient, not a subtraction. The `L1`-only row above is the bare-ODE
-(odelia Lorenz) degenerate case; its `set_target`/`advance_target` fit shape
-(`test-ad-workflow.R`) serves that case and must **not** set the shape of the primary
+Calibration is last because it additionally requires observations and a likelihood.
+Calibrating the plant SCM to data is the resident replay plus a likelihood functional — an
+addition over the emergent resident gradient, not a subtraction. The bare-ODE (odelia
+Lorenz) L1-only fit is the degenerate case, and its shape must not set the primary
 `stand_gradient()` UX.
 
 ---
 
 ## 6. User stories
 
-Each story is the R experience of one persona. The recurring point is what they
-*never* touch — the invariant of §2 paying off. The last line of each traces to the
-design and surfaces any requirement. Stories are ordered by priority: the emergent
-gradients (6.1 resident, 6.2 invasion) are the **primary** plant workflows and need
-no observations; calibration (6.3) is an **advanced** case that additionally assumes
-targets and a likelihood, and is included to test the invariant under a hot loop —
-not as the entry point.
+Each story is the R experience of one persona; the recurring point is what they *never*
+touch — the invariant of §2 paying off. The emergent gradients (6.1 resident, 6.2
+invasion) are the **primary** plant workflows and need no observations; calibration (6.3)
+is an **advanced** case that additionally assumes observations and a likelihood.
 
-### 6.1 Trait sensitivity — forest ecologist (plant, resident/total)
+### 6.1 Trait sensitivity — forest ecologist (resident/total)
 
-*"I have a calibrated FF16 stand; how do emergent LAI and biomass respond to leaf
-mass per area and wood density?"*
+*"I have a calibrated FF16 stand; how do emergent LAI and biomass respond to leaf mass per
+area and wood density?"*
 
 ```r
 scm <- run_scm(params, control = control(save_RK45_cache = TRUE))
@@ -217,14 +210,13 @@ g   <- stand_gradient(scm, metrics = c("LAI", "biomass"),
 g$jacobian     # 2x2 doubles: d(metric)/d(trait), with self-shading feedback
 ```
 
-Never touches XAD, an active type, a tape, or a second solver. The only AD-aware
-line is `save_RK45_cache = TRUE`, which belongs to the model run. *Traces to §4,
-§5; requires the native harvest (RIF-6) and C++ functional-by-name (§4.4).*
+Never touches XAD, an active type, a tape, or a second solver. The only AD-aware line is
+`save_RK45_cache = TRUE`, which belongs to the model run.
 
-### 6.2 Selection gradient — evolutionary ecologist (plant, mutant/invasion)
+### 6.2 Selection gradient — evolutionary ecologist (mutant/invasion)
 
-*"Give me the invasion-fitness gradient of a rare mutant against an established
-resident, so I can locate singular strategies."*
+*"Give me the invasion-fitness gradient of a rare mutant against an established resident,
+so I can locate singular strategies."*
 
 ```r
 resident <- run_scm(resident_params, control = control(save_RK45_cache = TRUE))
@@ -232,60 +224,51 @@ sel <- offspring_production_gradient(resident, traits = c("lma", "hmat"))
 # named double vector: d(fitness)/d(trait), resident canopy held frozen
 ```
 
-The frozen canopy and the `run_mutant` replay are entirely under the hood; the user
-picks the workflow by choosing the function, not by managing state. *Traces to the
-two-workflow model (design §6.1) and §4.3 (C++ dispatch).*
+The frozen canopy and the `run_mutant` replay are entirely under the hood; the user picks
+the workflow by choosing the function, not by managing state.
 
 ### 6.3 Gradient-based calibration — modeller fitting data (the hot loop) — *advanced*
 
 *"Run L-BFGS over traits to fit observations; call me for value and gradient each
-iteration."* (Advanced: unlike 6.1/6.2 this assumes the user has defined
-observations and a likelihood.)
+iteration."*
 
 ```r
 solver <- Solver$new(system, control)     # ONE ordinary (double) solver
-solver$set_target(times, obs, obs_idx)
+solver$set_observations(times, obs, obs_idx)
 optim(par,
       fn = \(p) solver$value_and_gradient(p)$value,     # doubles in/out
       gr = \(p) solver$value_and_gradient(p)$gradient,
       method = "L-BFGS-B")
 ```
 
-This is the **L1** replay (design §7): an adaptive run captures the ODE step
-schedule, then AD replays pinned to it — no environment cache. It is the story that
-most stresses the invariant — a tight loop that would be the natural place to "cache
-the active solver in R." It does not: the tape is reused through the opaque cache on
-the double solver (§3.3), and the user never sees an active handle or an `active =`
-flag. **Requirement surfaced:** expose a single `value_and_gradient(p)` that returns
-both from **one** recording, so `fn`/`gr` don't each re-run the tape (a pure
-`gradient()` and `loss()` would double the work in an optimizer). *Traces to
-§3.1/§3.3, RIF-1/RIF-3; adds `value_and_gradient` to RIF-1.*
+This is the **L1** replay: an adaptive run captures the ODE step schedule, then AD replays
+pinned to it. It is the story that most stresses the invariant — a tight loop that would
+be the natural place to "cache the active solver in R." It does not: the tape is reused
+through the opaque cache on the double solver (§3.3), and the user never sees an active
+handle. A single `value_and_gradient(p)` returns both from **one** recording, so `fn` and
+`gr` share the tape rather than each re-running it.
 
 ### 6.4 A new emergent metric — plant developer
 
-The shipped metrics are **LAI, biomass, and basal area** (plus
-`offspring_production`). Extensibility is the story: a developer adds "mean canopy
-height" (a tutorial-level example) with one scalar-templated kernel that reuses
-existing model functions and registers its name. Then:
+The shipped metrics are LAI, biomass, basal area, and `offspring_production`. A developer
+adds "mean canopy height" with one scalar-templated kernel that reuses existing model
+functions and registers its name:
 
 ```r
 stand_gradient(scm, metrics = "mean_height", traits = ff16_default_traits())
 ```
 
-works immediately — the C++ entry maps the name to the functional; the reverse
-sweep is odelia's. No tape code, no odelia change. *Traces to §4.4 and design §5;
-confirms "adding a metric is one kernel." mean-height lives in a tutorial, not the
-shipped set.*
+works immediately — the C++ entry maps the name to the functional; the reverse sweep is
+odelia's. No tape code, no odelia change.
 
 ### 6.5 A new ODE model — odelia downstream developer
 
-*"I'm building a hydraulics module on odelia; I want gradients without writing
-marshalling or tape code."*
+*"I'm building a hydraulics module on odelia; I want gradients without writing marshalling
+or tape code."*
 
 The developer implements the System contract — `value_type`, `set_params`,
-`set_initial_state`, and `rebind` (§3.2) — and gets `Solver_gradient` /
-`Solver_jacobian` for free, doubles only. odelia never learns what a hydraulic
-segment is. *Traces to §3.2; validates the plant-agnostic odelia surface.*
+`set_initial_state`, and `rebind` (§3.2) — and gets `Solver_gradient` / `Solver_jacobian`
+for free, doubles only. odelia never learns what a hydraulic segment is.
 
 ### 6.6 Trusting a gradient — maintainer (verification)
 
@@ -298,8 +281,7 @@ stopifnot(abs(g_ad - g_fd) < tol)
 ```
 
 Because the AD path returns doubles in the same shape as the finite-difference path,
-verification is a plain numeric comparison. *Traces to the doubles-only boundary and
-the regression oracle (UX-2).*
+verification is a plain numeric comparison.
 
 ### 6.7 Edge case — forgot the cache (fail loud, never confuse)
 
@@ -311,36 +293,52 @@ stand_gradient(scm, "LAI", "lma")
 #> Error: no resident schedule cached; re-run with control(save_RK45_cache = TRUE)
 ```
 
-A clear, actionable error — never a crash. This is the deliberate contrast with the
-§1.1 hazard: with active types off the R surface there is no wrong-typed handle to
-reinterpret, so the boundary can only fail loudly. *Traces to §2, §3.1.*
+A clear, actionable error — never a crash. With active types off the R surface there is no
+wrong-typed handle to reinterpret, so the boundary can only fail loudly.
+
+### 6.8 Enabling AD on a system with adaptive numerics — odelia downstream developer
+
+*"My hydraulics module's rates read an adaptively-refined interpolator — a bare ODE like
+Lorenz didn't. What must I implement so reverse-mode gradients are correct, and what if I
+also want a cheap run that holds part of the system fixed?"*
+
+6.5 answered this for a bare ODE: implement `value_type` / `set_params` /
+`set_initial_state` / `rebind`, and gradients come for free. Once the system has adaptive
+sub-numerics there are **two further, independent capabilities**, and keeping them separate
+is what removes the "cache" / "environment" confusion:
+
+**1. Node-position replay — required for AD, automatic, not a user flag.** Any adaptive
+construction makes parameter-dependent discrete decisions about where to place nodes;
+differentiating through those branches corrupts the tape. So the double pass records the
+node **positions** and the AD pass replays them **fixed**, while the values at those nodes
+stay fully differentiable. The ODE step schedule is universal and odelia owns it; if your
+system builds an interpolator or quadrature, you record its node positions through the
+`Replayable` hooks. This is switched on by *doing reverse-mode AD*, not by any user control
+— miss it and gradients are silently wrong wherever the adaptive component bites.
+
+**2. Value freeze — an optional variant workflow.** Separately, you may want a run that
+holds some *recomputable quantity* constant — its derivative zero by construction. plant's
+rare mutant reading a fixed resident field is one instance, but the quantity need not be an
+"environment" or an interpolator; it could be a held-fixed sub-state or frozen state
+variables. You record it on the double pass and read it frozen on a designated replay. This
+*is* a per-call choice, but the user expresses it by calling the variant entry (a
+`run_mutant`-style function), not a `feedback` flag — the workflow function *is* the choice.
+
+odelia stays agnostic to both: it records "some node positions" and "some values" and never
+learns a node is a height or a value an environment. You implement the `Replayable` hooks
+(`record_stage` / `record_ode_step` / `replay_step` / `has_recorded_field`); the variant
+entry (`run` vs `run_mutant`) chooses whether the frozen-field cache is populated, and
+`has_recorded_field()` reports it. The *user* does nothing for capability 1 (it rides the
+AD call) and picks the variant function for capability 2.
 
 ---
 
-## 7. Work items (feed `ad-issues.md`)
+## 7. Two design decisions to record
 
-| Item | Repo | Class | Note |
-|---|---|---|---|
-| RIF-1 | odelia | CP | `Solver_gradient`/`Solver_jacobian`/`value_and_gradient` on the double handle; retire the `active` flag + `ActiveSystemType` XPtr from the R surface |
-| RIF-2 | odelia | CP | `rebind` lift contract (§3.2) so the driver constructs the active system |
-| RIF-3 | odelia | CP-support | opaque tape/active-scratch cache on the double Solver (§3.3) |
-| RIF-4 | odelia | NTH | policy check: ensure no `wrap`/`as` for active types compiles |
-| RIF-5 | plant | CP | single `stand_gradient_cpp` entry taking the RcppR6 handle; C++ strategy/feedback dispatch (§4.1, §4.3) |
-| RIF-6 | plant | CP | native-pointer harvest; delete `Rcpp::as<*_Environment>` (ties to PLANT-4/5) |
-| RIF-7 | plant | CP-support | thin `stand_gradient()` R wrapper; remove R-side branching |
-
-**Dependencies:** RIF-1..3 sit under ODELIA-1/2/3 (they are the R-facing side of the
-driver). RIF-5..7 sit under PLANT-4/5 (native harvest) and UX-1 (stable surface).
-None require exposing an active type to R; that is the point.
-
-## Open questions
-
-- **Keep any R-visible active solver at all?** An advanced user driving a bespoke
-  optimizer loop in R might want to hold AD state across calls. The opaque-cache
-  approach (§3.3) covers the common case; decide whether a power-user escape hatch
-  is worth the re-introduced footgun. Recommendation: no — start with the invariant,
-  add an escape hatch only on a demonstrated need.
-- **RcppR6 template-type dispatch.** `stand_gradient_cpp` must resolve the SCM's
-  `<T,E>` (FF16 / TF24 / TF24f) to instantiate the right replay. Confirm whether
-  this dispatch is best done by the existing `extract_RcppR6_template_types` (R
-  side, strings) feeding a C++ `switch`, or a C++-side type tag on the handle.
+- **No R-visible active solver — not even a power-user escape hatch.** An advanced user
+  driving a bespoke optimizer loop in R might want to hold AD state across calls, but the
+  opaque cache (§3.3) already covers the hot loop without re-introducing the wrong-typed
+  handle. The invariant wins; an escape hatch waits for a demonstrated need.
+- **RcppR6 template-type dispatch.** `stand_gradient_cpp` resolves the SCM's `<T,E>`
+  (FF16 / TF24 / TF24f) to instantiate the right replay. The dispatch is done in C++ — a
+  strategy tag off the handle feeding a `switch` — so the active types never surface in R.

--- a/notes/ad-design/ad-record-replay.md
+++ b/notes/ad-design/ad-record-replay.md
@@ -1,0 +1,345 @@
+# AD record → replay: the one adaptive-numerics primitive
+
+**Scope:** `traitecoevo/odelia` — the record→replay primitive beneath every adaptive
+construction on the AD path. It applies in plant unchanged in shape: the light spline
+and the crown quadrature record the same way, and the plant `QK` node-set slots into
+the identical machinery.
+**Companions:** [`ad-infrastructure-design.md`](./ad-infrastructure-design.md) (the
+plant emergent-gradient design this primitive sits under);
+[`ad-r-interface.md`](./ad-r-interface.md) (the R/C++ boundary and the reuse of the
+active solver across calls).
+
+---
+
+## 1. Thesis
+
+Every adaptive numerical construction in the stack — the RKCK stepper, the light
+interpolator, the crown-depth quadrature — exists to *discover where to place nodes*
+to hit a tolerance **without knowing the answer**. On a gradient pass the adaptive run
+has already happened, so the node placement is already known. Re-discovering it is pure
+overhead, and differentiating *through* the adaptive branching is fragile. So:
+
+> **Record** where the double (adaptive) pass placed its nodes. **Replay** pinned to
+> those nodes with the active scalar — no adaptive branching — and read the adjoints.
+
+The double pass, once recorded, is **immutable**: its only job is to feed replays. This
+is one idea. The apparent "levels" (§3) are the same idea at different depths, and they
+collapse to a single System concept (§5).
+
+---
+
+## 2. The system, in four names
+
+An AD run holds exactly three nouns and one verb; the whole design fits in them.
+
+- **the double solver** (`d`) — the real adaptive run. R holds it. It is immutable
+  after its pass, and it **owns the recording**.
+- **the active solver** — the double System lifted to the active scalar (the *rebind*):
+  the differentiable solver the gradient runs on. It holds **no** semantics between
+  calls — it is re-seeded and re-fed the recording every call.
+- **the recording** — the schedule plus the node stash the double pass produced, read
+  *per call*.
+- **replay** (the verb) — the active solver re-running the double's recorded schedule
+  with the active scalar.
+
+Reuse of the active solver and its tape (§7) is a *property* of it, not a concept of
+its own: it is kept on the double solver and reused so an optimiser loop does not
+rebuild it. It never changes a number.
+
+---
+
+## 3. Ownership sets the layers
+
+The **Solver** is the generic engine: it steps arbitrary systems, either adaptively
+(discovering node positions) or on a fixed grid (replaying them). The **System** owns
+whatever field it builds to compute its rates. That ownership split *is* the layer
+ladder:
+
+| Layer | Recorded thing | Cadence | Owner | Needs |
+|---|---|---|---|---|
+| **L1** | the step **schedule** (`recorded_steps()` = `times()`) | per accepted step | **Solver** | nothing — always present, always differentiable |
+| **L2** | the System's adaptive **node positions** (interpolator knots, `QK`/QAG subdivision) | **per step** | **System** | *record positions* |
+| **L3** | the System's **background field** values | **per RK stage** | **System** | *record positions and values, and freeze* |
+
+L1 is universal: every ODE has a stepper, so every System replays its schedule via
+`advance_fixed(recorded_steps())` with no System participation. L2 and L3 are the
+System's own state; the stepper only signals cadence.
+
+### 3.1 Positions are per step; values are per stage
+
+The cadences follow from what each freeze is *for*.
+
+**Positions freeze per step.** The only reason to freeze node positions is to keep the
+parameter-dependent adaptive *branching* off the tape — the refinement decisions are
+`double`-valued control flow. One representative position set per step removes the
+branching completely, and it is representative *by construction*: the step-size
+controller accepts a step only when the RKCK error estimate stays under tolerance —
+only when the state, and hence the field's adaptive structure, varies within the step
+by less than tolerance. Any residual difference between a step's representative
+positions and a stage's ideal positions is below tolerance: the noise floor the
+adaptive scheme already accepts. Recording positions per stage would be six times the
+storage to resolve something already inside the tolerance band.
+
+**Values freeze per stage.** A frozen background is different in kind: each RK stage
+evaluates the field at a genuinely different state, and a frozen consumer must read
+back the *exact* value that stage consumed — a real quantity, not a discretization
+choice. A per-step value would be wrong, not merely coarse.
+
+### 3.2 One recording, read as two slices
+
+A single double pass records the **union** — positions *and* values — in one
+accumulate/commit cycle (§5). Each consumer reads its slice:
+
+| Consumer | Reads | On the active pass | Cross term |
+|---|---|---|---|
+| **resident / total** (live) | the recorded **positions** | recompute the field on frozen positions with active state → self-feedback flows | present |
+| **mutant / invasion** (frozen) | the recorded **values** | read as `double` background — off the tape, no recompute; only the mutant's own state is active | zero |
+
+The union is forced by cross-feedback: a `run_mutant` reads the *resident's* per-stage
+values, so the resident's `run` must record values for mutants it cannot foresee. It
+records them for free — the per-stage hook captures the positions (at stage 0) and the
+values (each stage) together. plant records exactly this union (`stand_height_history`
+positions and `environment_history` values, `patch.h`).
+
+---
+
+## 4. Generality: not the interpolator, not the environment
+
+Because the recording is System state and the core hooks carry only cadence, both
+freezes generalise past any one example:
+
+- **L2 is any adaptive component.** The record hooks stash whatever *positions* a
+  System's adaptive machinery chose — spline knots for an interpolator, the
+  Gauss–Kronrod subdivision for a quadrature, or a *list* of position-sets for a System
+  with several (a TF24 Patch records the light-spline knots and the crown-depth
+  quadrature nodes through the identical hooks). Nothing in the concept or `derivs`
+  names a knot.
+- **L3 is any recomputable sub-state.** A frozen background is whatever doubles a System
+  stashed per stage — a held-fixed sub-state, frozen state variables, a canopy — not
+  specifically an interpolated field. `derivs` calls `set_ode_state(y, index)` and the
+  System decides what that reads.
+
+"Environment" is a plant term; the odelia-neutral word is **field** — the background
+coupling a rate reads. odelia grows no `Recording` noun and no replayable-interpolator
+class: the schedule is `times()` (Solver state), the positions and values are thin
+System state, and the numeric (interpolator, quadrature) is stateless and rebuilt from
+the recording.
+
+---
+
+## 5. One `Replayable` concept: three signals and one query
+
+There is **one** System, driven live or frozen per call (`run` vs `run_mutant`), and
+one concept the stepper dispatches on behind `if constexpr (Replayable<System>)`. An
+absent hook makes every call site a zero-cost no-op; nothing forces a System to be
+differentiable or replayable.
+
+```cpp
+template <class S>
+concept Replayable = requires(S s, int stage) {
+  s.record_stage(stage);                                   // accumulate (per RK stage)
+  s.record_ode_step();                                     // commit    (per accepted step)
+  s.replay_step();                                         // load      (per step, active pass)
+  { s.has_recorded_field() } -> std::convertible_to<bool>; // the frozen-field query
+};
+```
+
+The three signals are the two nested loops of the adaptive stepper, not two recordings:
+
+| Signal | Fires | Job |
+|---|---|---|
+| `record_stage(k)` | per RK stage, record pass | accumulate the union (positions@0, value@k) into scratch |
+| `record_ode_step()` | per **accepted** step, record pass | commit the scratch → recording |
+| `replay_step()` | per step, active pass, before the stages | load this step's positions / advance the recording index |
+
+`record_stage` and `record_ode_step` are two because adaptive step **rejection** forces
+commit-on-accept: a rejected step re-runs its stages, harmlessly clobbering the scratch;
+only an accepted step commits. Folding the commit into the per-stage hook would record
+rejected steps. `replay_step` is separate because positions must load *before* a step's
+stages run. Three signals, one query — the minimal seam. (The per-step commit takes the
+`_ode_` infix because a System's `record_step()` already serializes one collected state
+to a history row; the two must not collide.)
+
+### 5.1 The runtime state is two bits
+
+A Replayable System needs to know only two things at runtime: **is it recording?**, and
+when replaying, **is the field frozen?** (mutant) or recomputed live (resident). Those
+are the only distinctions the hooks and the query branch on:
+
+- `record_stage` / `record_ode_step` act only while **recording**.
+- `has_recorded_field()` reports whether the L3 field cache is populated — the query
+  `derivs` reads to route mutant replay.
+- `replay_step` acts whenever replaying, which is *derived*, not stored: a System is
+  replaying exactly when it is **not** recording and **has** a recording to read.
+
+The core sees only the four concept members; how a System backs them is its own business.
+
+---
+
+## 6. Control flow of an AD run
+
+Three runs share the identical stepper, `advance_fixed`, and tape machinery. They differ
+in exactly three slots: which **system** the active solver carries, which **slice** of
+the recording it reads, and the `has_recorded_field()` **query** inside `derivs`.
+
+### 6.1 `run` (double) — the record pass
+
+```
+d.advance_adaptive({0, T})                                   [recording]
+  per adaptive step  step():
+    retry loop:
+      stepper.step():  6 RK stages
+        per stage k:  derivs(sys, y, k, t):  set_ode_state(y, t)   ← field on ADAPTIVE positions
+                      record_stage(k)                              → accumulate: positions@0, value@k
+      accept? ─no─→ shrink h, undo y/t, retry   (scratch clobbered)
+             └yes─→ record_ode_step()                              → COMMIT scratch → recording[step]
+  ⇒ recording = schedule times() (L1) + positions/step (L2) + values/step×stage (L3)
+     owned by d, immutable hereafter
+```
+
+### 6.2 `run` (active) — resident / live gradient
+
+The active solver carries the resident system, reads its **own** recording, and
+recomputes the field so self-feedback flows.
+
+```
+active = active_solver(d)                                    [replay, live field]
+  schedule  → advance_fixed grid          (L1, Solver→Solver)
+  recording → active.system  (positions read, values ignored) (L2, System→System)
+  tape on; computeJacobian(trait/IC seeds, forward):
+    forward(x):
+      active.system.scatter(x, slots); active.reset()
+      active.advance_fixed(recorded_steps()):   ← replay schedule, NO adaptivity
+        per step step_to:
+          replay_step()                    → load THIS step's frozen positions
+          stepper.step(): per stage derivs(...,k):
+            query false → set_ode_state(y, t)   REBUILD field on FROZEN positions,
+                                                ACTIVE values (gradient flows; self-feedback)
+      return state
+    seed adjoints → sweep → ∂functional/∂trait   (with self-feedback)
+  tape off
+```
+
+### 6.3 `run_mutant` (active) — mutant gradient
+
+The active solver carries the mutant system, reads the **resident's** recording as fixed
+background, and the field is read back off-tape (its derivative zero).
+
+```
+active = active_solver(d_resident)  (mutant system)          [replay, frozen field]
+  schedule           → advance_fixed grid   (L1)
+  RESIDENT recording → active.system  (values read, positions ignored)  (L3, System→System)
+  tape on; computeJacobian(MUTANT seeds, forward):
+    forward(x):
+      active.system.scatter(x, slots); active.reset()  ← background ← recorded value[0]
+      active.advance_fixed(recorded_steps()):
+        per step step_to:
+          replay_step()                    → advance index (positions unused)
+          stepper.step(): per stage derivs(...,k):
+            query true → set_ode_state(y, k)   read recorded value @stage k as DOUBLE
+                                               background (off tape, ∂/∂field = 0)
+      return mutant state
+    seed adjoints → sweep → ∂functional/∂mutant-trait   (field contribution 0)
+  tape off
+```
+
+The only forks are inside `derivs`, keyed by the query; the stepper never learns what a
+position *is*. The differentiation trick, stated once: on replay the node **positions**
+are frozen doubles (no adaptive branching to corrupt the tape) while the node **values**
+stay active — so the gradient flows through *what the nodes hold*, never through *where
+they sit*. L3 goes one step further and takes the field off the tape entirely.
+
+---
+
+## 7. Reuse the active solver, read the recording per call
+
+A gradient call builds an active solver, records a tape, sweeps it, and reads adjoints.
+An optimiser loop (or a batch of mutants against one recording) calls this repeatedly.
+Rebuilding the active solver and reallocating the tape every call is waste; the reuse
+stays invisible to R.
+
+**The active solver is the only cached thing.** The gradient runs on it, and a `Solver`
+carries its own `tape`, so that tape *is* the reused tape — there is nothing else to
+cache. It is held on the double solver, and its type is **named, not erased**: the
+System supplies `rebind`, so `System::rebind<active>` spells the active solver's type
+from inside `Solver<System>` — no `void*`, no `static_cast`.
+
+**Anchored on the Solver object, not an R handle.** plant holds the solver as a plain
+C++ member (`scm.h`: `Solver<patch_type> solver;`) and never wraps it in an XPtr, so an
+anchor on the R handle would be invisible to it. Anchoring the active solver on the
+`Solver` object gives the SCM the reuse for free.
+
+**The recording is read per call, never frozen into the active solver.** The schedule
+and node stash live on the immutable double solver/System and are handed over on every
+call — not snapshotted at first build, not carried through `rebind` (which lifts values
+only), not smuggled onto the solver as fit state. Each consumer hands its own slice: the
+calibration entry hands its observations (in the `least_squares` functional), a
+record→replay System hands its recording. The number a gradient returns comes entirely
+from the per-call recording and seeds.
+
+**Validity domain.** The recording is keyed to the ICs and params of the double run;
+those fix the schedule and the positions. A cached run may be replayed with a different
+**mutant** or a different **functional / observations**. Changing ICs or params
+invalidates the recording and forces a re-record — reading it per call is what makes
+that pickup automatic rather than a stale reuse. `has_recording()` and
+`recorded_steps()` are the read-only surface behind the "forgot to record" guard.
+
+Two senses of "cache" stay distinct: **cache = the amortized active solver + tape
+(speed); record/replay = the recording (semantics).** Reusing the cache never changes a
+number; the recording is what does.
+
+---
+
+## 8. Calibration is one functional, not the foundation
+
+The foundational blocks are **an arbitrary functional** — a **pure reduction**: it reads
+a replayed System and returns the scalar(s); it does not drive the solver — and
+**replay-fixed** (this doc): the driver replays the recorded schedule and hands the
+functional a positioned solver. `least_squares` is one functional built on them: it owns
+only its measured **observations** and which recorded steps they attach to, and reads the
+model's state at those steps. The schedule is the recording's, never the functional's. An
+emergent functional reads native state at the recorded steps and carries no observations.
+Calibration is one case among many, not the primary one — and its data lives in the
+functional, not the solver.
+
+---
+
+## 9. The odelia-native demonstrator
+
+Lorenz and leaf_thermal have no adaptive sub-numerics, so `Replayable` is exercised by a
+purpose-built System: the odelia-native shrink of FF16's resident light — a scalar state
+whose rate reads a field built by an adaptive interpolator over state-dependent node
+positions. It carries one differentiable input and exercises all three depths against
+finite differences:
+
+- **L1 — schedule freeze.** Record `times()` on the double solver; replay `advance_fixed`
+  on the active solver. Value reproduces to floating point; gradient matches central FD.
+- **L2 — interpolator freeze (live).** Record the knots per step; replay with frozen
+  positions carrying active values, field recomputed. Value + gradient-vs-FD.
+- **L3 — frozen field.** Read the recorded per-stage values as `double` background; the
+  trajectory reproduces the resident and the field's gradient contribution is zero (the
+  invasion property in miniature). The field is plain double data — never an active
+  constant with a zeroed derivative.
+- **Reuse.** On a persistent double solver, repeated gradient calls reuse the active
+  solver and tape and reproduce; a recording from a *fresh* double pass is picked up per
+  call (the anti-staleness property an L1-only cache cannot express); live and frozen
+  replays share one active solver with the mode chosen per call; replay-before-record
+  errors.
+
+---
+
+## 10. Mapping to plant (FF16 / TF24 / TF24f)
+
+The Systems differ only in **which node-sets** they record — a *list* of position-sets,
+each read live or frozen:
+
+- **FF16** records the light-spline knots. Resident → live recompute; mutant → frozen.
+  The direct analogue of §9.
+- **TF24 / TF24f** additionally record the crown-depth quadrature nodes and route the
+  leaf-optimizer sensitivity through a supplied derivative. TF24f's coupled resident
+  feedback is the stiff long-horizon boundary.
+
+The plant `QK<S>` quadrature is out of odelia scope, but it is the same shape as the
+interpolator — record positions, replay fixed, choose frozen or live — so plant adds a
+quadrature node-set with no new mechanism. The single-concept, positions-vs-values model
+is what guarantees that.


### PR DESCRIPTION
## Summary

This is a **design-only** PR — it adds a roadmap for the plant SCM automatic-differentiation
work, with no code changes. It proposes how to land the exact trait/birth-rate gradients
prototyped in #553 with **surgical changes to the existing plant components** plus a small
generic surface added to **odelia**, rather than as a plant-private AD stack.

The prototype in #553 is validated (gradients to ~1e-13) and remains the specification and
the regression oracle throughout. This roadmap is about *how to merge that capability* with
lower long-term technical debt.

## What's included

A set of design docs (under `notes/`):

- **`README.md`** — orientation, reading order, and a glossary for readers new to the model
  or to AD.
- **`ad-infrastructure-design.md`** — the design: three layers (odelia / plant / UX), the
  surgical changes, the two workflows (resident vs. invasion), and the four replay levels.
- **`ad-r-interface.md`** — the R/C++ boundary (why XAD types are awkward through Rcpp, the
  "only doubles cross" invariant) plus user stories for each persona.
- **`ad-issues.md`** — the work breakdown: scoped items across odelia / plant / R-boundary /
  prototypes, with dependencies and a critical-path build order.

## Key design positions

- **odelia owns the generic AD mechanism** (tape, reverse-mode Jacobian, the functional
  seam, IFT/analytic edges) it already almost provides; plant keeps only irreducible
  physiology. plant already `LinkingTo: odelia`.
- **Surgical, not parallel.** The Patch is already an `odelia::ode::Solver` System, and
  `SCM::run_mutant()` is already the frozen-schedule replay — the gradients differentiate the
  runs we already have, not three bespoke `*_emergent.cpp` engines. The `<T,E,S>` third
  axis collapses to the existing `<T,E>` with the scalar carried by the strategy/environment.
- **One replay primitive** — "record where the adaptive stepper/interpolator/quadrature
  placed their nodes, replay on them fixed with the active scalar" — which removes the
  `stand_stage_history` machinery and reuses `basic_interpolator<S>`/`QK<S>`.
- **Reverse mode** for the metrics×traits Jacobian; forward mode stays plant-local at the
  leaf optimizer.

## Relationship to #553

This does not replace #553 — it plans how to land its result. The recommendation is to **not
merge the spike as-is** but to codesign the odelia surface first (with the spike's validated
Jacobians as the AD-vs-AD oracle), then rebuild the plant path onto it strategy by strategy.
The docs are explicit about scope and risk, including the TF24 leaf-optimizer cross-sensitivity
and the TF24f long-horizon stiffness limit.

## Scope note

The design spans both plant and odelia; the odelia-side work items are scoped here for
coordination even though they land in `traitecoevo/odelia`. Feedback on the direction is
welcome before implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)