### PR TITLE
Say where light-spline refinement stalled, and what the patch was doing there (#571)

### DIFF
--- a/inst/include/plant/adaptive_interpolator.h
+++ b/inst/include/plant/adaptive_interpolator.h
@@ -5,11 +5,34 @@
 // This class creates an interpolator object, using adaptive refinement
 
 #include <list>
+#include <stdexcept>
+#include <string>
 #include <plant/util.h> // util::stop, util::seq_len
 #include <odelia/interpolator.hpp>
 
 namespace plant {
 namespace interpolator {
+
+// Where refinement gave up: the worst interval still failing the error test at
+// max_depth, and how many others are in the same state. Reported because the
+// location is the diagnosis -- refinement stalls on a feature of the target, and
+// naming the x it stalled at points straight at whatever put the feature there.
+struct StallReport {
+  double x_lo, x_hi;   // the unresolved interval
+  double y_lo, y_hi;   // target values at its ends
+  size_t n_unresolved; // intervals still failing, including this one
+};
+
+// Thrown when adaptive refinement exhausts max_depth. Carries the stall location
+// so a caller with model context can say what lives at that x before the error
+// reaches the user: the interpolator only sees a function with a narrow feature,
+// whereas Patch knows it is a light profile over a set of cohort heights.
+class refinement_failure : public std::runtime_error {
+public:
+  refinement_failure(const std::string& msg, const StallReport& report_)
+    : std::runtime_error(msg), report(report_) {}
+  StallReport report;
+};
 
 class AdaptiveInterpolator {
 public:
@@ -43,6 +66,11 @@ private:
   bool check_err(double y_true, double y_pred) const;
   static void check_bounds(double a, double b);
   static void check_target_value(double x, double y);
+
+  // Locate the interval refinement is stuck on, and throw refinement_failure
+  // naming it. Non-template members, so they live in the .cpp.
+  StallReport stall_report() const;
+  [[noreturn]] void stop_unresolvable() const;
 
   // Control parameters:
   double atol, rtol;
@@ -101,17 +129,11 @@ bool AdaptiveInterpolator::refine(Function target) {
   dx /= 2;
 
   if (dx < dxmin) {
-    // Say what was actually exhausted. The target is finite here (construct()
-    // and the loop below both check), so this is a genuine resolution limit:
-    // the function has a feature narrower than dxmin, i.e. is effectively
-    // discontinuous at this tolerance.
-    util::stop("Interpolated function as refined as currently possible: "
-               "spacing " + util::to_string(dx) + " is below the limit " +
-               util::to_string(dxmin) + " set by max_depth=" +
-               util::to_string(static_cast<int>(max_depth)) +
-               ", and the target still misses atol=" + util::to_string(atol) +
-               " / rtol=" + util::to_string(rtol) +
-               ". The target has a feature narrower than that spacing.");
+    // Say what was actually exhausted, and where. The target is finite here
+    // (construct() and the loop below both check), so this is a genuine
+    // resolution limit: the function has a feature narrower than dxmin, i.e. is
+    // effectively discontinuous at this tolerance.
+    stop_unresolvable();
   }
 
   bool flag = false;

--- a/inst/include/plant/patch.h
+++ b/inst/include/plant/patch.h
@@ -605,20 +605,35 @@ std::string Patch<T,E>::describe_nodes_near(double height) const {
                     util::format_double(environment.time) + "):";
 
   for (size_t i = 0; i < species.size(); ++i) {
-    size_t n_near = 0, n_inversions = 0;
+    size_t n_near = 0, n_inversions = 0, n_inversions_live = 0, n_zero_density = 0;
     double h_near_min = std::numeric_limits<double>::infinity(),
            h_near_max = -std::numeric_limits<double>::infinity(),
            h_max = -std::numeric_limits<double>::infinity(),
            h_front = NA_REAL, h_prev = NA_REAL;
+    bool prev_live = false;
 
     for (auto it = species[i].node_begin(); it != species[i].node_end(); ++it) {
       const double h = it->height();
+      const bool live = it->get_density() > 0.0;
+      if (!live) {
+        n_zero_density++;
+      }
       if (!util::is_finite(h_front)) {
         h_front = h;
       } else if (h > h_prev) {
         n_inversions++;
+        // Whether the *live* cohorts are still ordered is the question that
+        // matters: the method of characteristics guarantees it for them (growth
+        // trajectories sharing an environment cannot cross), so inversions among
+        // zero-density nodes are bookkeeping debris in the quadrature grid,
+        // whereas an inversion between two live cohorts would mean the
+        // characteristics themselves had crossed.
+        if (live && prev_live) {
+          n_inversions_live++;
+        }
       }
       h_prev = h;
+      prev_live = live;
       h_max = std::max(h_max, h);
       if (fabs(h - height) <= window) {
         n_near++;
@@ -643,13 +658,22 @@ std::string Patch<T,E>::describe_nodes_near(double height) const {
     }
     if (n_inversions > 0) {
       ret += "; node heights are NOT decreasing (" +
-             util::to_string(n_inversions) +
-             " inversions), which breaks the ordering that"
+             util::to_string(n_inversions) + " inversions, " +
+             util::to_string(n_inversions_live) +
+             " of them between two cohorts of non-zero density; " +
+             util::to_string(n_zero_density) + " of " +
+             util::to_string(species[i].size()) +
+             " nodes have zero density), which breaks the ordering that"
              " Species::compute_competition() and height_max() assume: the"
              " tallest cohort is " + util::format_double(h_max) +
              " but height_max() reports " + util::format_double(h_front) +
              " (the front node), so the competition profile is wrong and its"
              " steps are an artefact rather than a feature of the model";
+      if (n_inversions_live == 0) {
+        ret += " (the live cohorts are still correctly ordered, so this is the"
+               " quadrature grid being scrambled by zero-density nodes rather"
+               " than growth trajectories crossing)";
+      }
     }
     ret += ";";
   }

--- a/inst/include/plant/patch.h
+++ b/inst/include/plant/patch.h
@@ -5,12 +5,15 @@
 #include <plant/parameters.h>
 #include <plant/species.h>
 #include <plant/util.h>
+#include <plant/adaptive_interpolator.h> // interpolator::refinement_failure
 #include <odelia/ode_interface.hpp>
 
 #include <plant/disturbance_regime.h>
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
+#include <string>
 
 using namespace Rcpp;
 
@@ -38,6 +41,11 @@ public:
   double height_max() const;
 
   double compute_competition(double height) const;
+
+  // Describe the size distribution around `height`, for error messages. The
+  // light spline is built from the cohort heights, so when its refinement fails
+  // the useful thing to report is what the cohorts are doing there.
+  std::string describe_nodes_near(double height) const;
 
   // * Lifetime fitness / offspring production
   // These are patch-level quantities: each integrates the per-node weighted
@@ -561,13 +569,92 @@ std::vector<std::vector<double>> Patch<T,E>::refinement_error_by_node() const {
 // Creates splines of resource availability
 template <typename T, typename E>
 void Patch<T,E>::compute_environment(bool rescale) {
-  
+
   // Define an anonymous function to use in creation of environment
   auto f = [&](double x) -> double { return compute_competition(x); };
 
   if (size() > 0 & !is_mutant_run) {
-    environment.compute_environment(f, height_max(), rescale);
+    try {
+      environment.compute_environment(f, height_max(), rescale);
+    } catch (const interpolator::refinement_failure& e) {
+      // The refiner can only say that the profile has a feature it cannot
+      // resolve, at some height. We know what is at that height, and it is
+      // usually the actual problem: cohorts stacked at one size put a step in
+      // the competition profile (#571). Say so rather than making the reader
+      // reconstruct the patch state by hand.
+      util::stop(std::string(e.what()) + " " +
+                 describe_nodes_near(e.report.x_lo));
+    }
   }
+}
+
+// Report what the size distribution is doing around `height`: how many cohorts
+// sit within a narrow window of it, and -- the usual culprit -- whether the node
+// list is still ordered by decreasing height. Species::compute_competition() and
+// Species::height_max() both take that ordering as given (see the invariant noted
+// on both), so once it is violated the competition profile they build has
+// fictitious steps in it, and the refiner fails on one of them (#571).
+//
+// A window rather than a single point because the unresolved interval is ~1e-5 m
+// wide, while what matters is whether cohorts share effectively the same size.
+template <typename T, typename E>
+std::string Patch<T,E>::describe_nodes_near(double height) const {
+  const double window = 1e-3; // m
+
+  std::string ret = "Patch state at that height (time " +
+                    util::format_double(environment.time) + "):";
+
+  for (size_t i = 0; i < species.size(); ++i) {
+    size_t n_near = 0, n_inversions = 0;
+    double h_near_min = std::numeric_limits<double>::infinity(),
+           h_near_max = -std::numeric_limits<double>::infinity(),
+           h_max = -std::numeric_limits<double>::infinity(),
+           h_front = NA_REAL, h_prev = NA_REAL;
+
+    for (auto it = species[i].node_begin(); it != species[i].node_end(); ++it) {
+      const double h = it->height();
+      if (!util::is_finite(h_front)) {
+        h_front = h;
+      } else if (h > h_prev) {
+        n_inversions++;
+      }
+      h_prev = h;
+      h_max = std::max(h_max, h);
+      if (fabs(h - height) <= window) {
+        n_near++;
+        h_near_min = std::min(h_near_min, h);
+        h_near_max = std::max(h_near_max, h);
+      }
+    }
+
+    ret += " species " + util::to_string(i + 1) + ": " +
+           util::to_string(n_near) + " of " +
+           util::to_string(species[i].size()) + " cohorts within " +
+           util::format_double(window) + " m";
+    if (n_near > 0) {
+      ret += ", spanning [" + util::format_double(h_near_min) + ", " +
+             util::format_double(h_near_max) + "]";
+      // Several cohorts at one size means growth has stalled and the schedule is
+      // introducing new cohorts into a patch with nothing to separate them.
+      if (n_near > 1 && (h_near_max - h_near_min) < window / 100) {
+        ret += " -- effectively a single size, so the size distribution has"
+               " collapsed here";
+      }
+    }
+    if (n_inversions > 0) {
+      ret += "; node heights are NOT decreasing (" +
+             util::to_string(n_inversions) +
+             " inversions), which breaks the ordering that"
+             " Species::compute_competition() and height_max() assume: the"
+             " tallest cohort is " + util::format_double(h_max) +
+             " but height_max() reports " + util::format_double(h_front) +
+             " (the front node), so the competition profile is wrong and its"
+             " steps are an artefact rather than a feature of the model";
+    }
+    ret += ";";
+  }
+
+  return ret;
 }
 
 

--- a/inst/include/plant/util.h
+++ b/inst/include/plant/util.h
@@ -127,6 +127,12 @@ std::string to_string(T x) {
   return std::to_string(x);
 }
 
+// to_string() always gives six decimal places, so quantities much smaller than
+// 1e-6 print as "0.000000" -- useless in an error message about spacings and
+// tolerances. This keeps six *significant* figures instead, so 15.7 and 1.5e-05
+// both read correctly.
+std::string format_double(double x);
+
 template <class ForwardIterator>
 void rescale(ForwardIterator first, ForwardIterator last,
              double min_old, double max_old,

--- a/src/adaptive_interpolator.cpp
+++ b/src/adaptive_interpolator.cpp
@@ -1,6 +1,7 @@
 #include <plant/adaptive_interpolator.h>
 #include <Rcpp.h>
 #include <plant/util_post_rcpp.h>
+#include <cmath>
 
 // Test hook: adaptively interpolate an R function, and return the knots chosen.
 // The production caller (ResourceSpline, for the light profile) passes a C++
@@ -57,6 +58,72 @@ void AdaptiveInterpolator::check_target_value(double x, double y) {
                util::to_string(y) + ") at x = " + util::to_string(x) +
                "; refinement cannot fix a non-finite value.");
   }
+}
+
+// Find the interval refinement is stuck on. zz[i] flags the interval
+// (xx[i-1], xx[i]) as still failing the error test; every one of them is about
+// 2*dx wide at this point, so the informative one is the one across which the
+// target moves furthest -- that is the feature refinement cannot resolve.
+StallReport AdaptiveInterpolator::stall_report() const {
+  StallReport ret = {xx.front(), xx.back(), yy.front(), yy.back(), 0};
+  double jump_max = -1.0;
+
+  std::list<double>::const_iterator xi = xx.begin(), yi = yy.begin();
+  std::list<bool>::const_iterator zi = zz.begin();
+  double x_prev = *xi, y_prev = *yi;
+
+  for (++xi, ++yi, ++zi; xi != xx.end(); ++xi, ++yi, ++zi) {
+    if (*zi) {
+      ret.n_unresolved++;
+      const double jump = fabs(*yi - y_prev);
+      if (jump > jump_max) {
+        jump_max = jump;
+        ret.x_lo = x_prev;
+        ret.x_hi = *xi;
+        ret.y_lo = y_prev;
+        ret.y_hi = *yi;
+      }
+    }
+    x_prev = *xi;
+    y_prev = *yi;
+  }
+
+  return ret;
+}
+
+// Report a resolution limit, naming the interval it was hit on.
+//
+// The bare "as refined as currently possible" message says only that some
+// feature is too narrow, which leaves the reader to find it by hand -- an
+// afternoon's work in the case that prompted this (#571: a dryland patch whose
+// cohorts had all stalled at the introduction height, putting a step in the
+// light profile). The location turns that into a one-line diagnosis, and callers
+// with model context add to it by catching refinement_failure.
+[[noreturn]] void AdaptiveInterpolator::stop_unresolvable() const {
+  const StallReport r = stall_report();
+
+  std::string msg =
+      "Interpolated function as refined as currently possible: spacing " +
+      util::format_double(dx) + " is below the limit " +
+      util::format_double(dxmin) + " set by max_depth=" +
+      util::to_string(static_cast<int>(max_depth)) +
+      ", and the target still misses atol=" + util::format_double(atol) +
+      " / rtol=" + util::format_double(rtol) +
+      ". The target has a feature narrower than that spacing";
+
+  if (r.n_unresolved > 0) {
+    msg += ", at x = " + util::format_double(r.x_lo) + ": across [" +
+           util::format_double(r.x_lo) + ", " + util::format_double(r.x_hi) +
+           "] the target jumps from " + util::format_double(r.y_lo) + " to " +
+           util::format_double(r.y_hi) + " (" +
+           util::to_string(r.n_unresolved) +
+           " interval(s) still unresolved, over the domain [" +
+           util::format_double(xx.front()) + ", " +
+           util::format_double(xx.back()) + "])";
+  }
+  msg += ".";
+
+  throw refinement_failure(msg, r);
 }
 
 // Determines if difference between predicted and true values falls

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,7 @@
 #include <plant/util.h>
 #include <Rcpp.h>
+#include <iomanip>
+#include <sstream>
 
 namespace plant {
 namespace util {
@@ -47,6 +49,12 @@ std::vector<double> seq_len(double from, double to, size_t len) {
     ret.push_back(x);
   ret.back() = to; // Protect against rounding errors.
   return ret;
+}
+
+std::string format_double(double x) {
+  std::ostringstream out;
+  out << std::setprecision(6) << x;
+  return out.str();
 }
 
 [[noreturn]] void stop(const std::string& msg) {

--- a/tests/testthat/test-tf24-arid-corner.R
+++ b/tests/testthat/test-tf24-arid-corner.R
@@ -67,3 +67,51 @@ test_that("adaptive interpolation names a non-finite target", {
   # A smooth target is unaffected.
   expect_silent(test_adaptive_interpolator(function(x) sin(x), 0, 1))
 })
+
+test_that("a resolution limit says where refinement stalled", {
+  # Naming the x is the whole diagnosis: refinement stalls on a feature of the
+  # target, so the location points straight at whatever put the feature there.
+  # Without it the message says only that some feature somewhere is too narrow
+  # (#571 took an afternoon to localise by hand).
+  msg <- tryCatch(
+    test_adaptive_interpolator(function(x) as.numeric(x > 0.5), 0, 1),
+    error = conditionMessage)
+
+  expect_match(msg, "at x = ")
+  x <- as.numeric(sub(".*at x = ([0-9.e+-]+):.*", "\\1", msg))
+  expect_equal(x, 0.5, tolerance = 1e-3)
+  # And what the target does across the interval it could not resolve.
+  expect_match(msg, "jumps from 0 to 1")
+  expect_match(msg, "interval\\(s\\) still unresolved")
+})
+
+test_that("a failed light spline reports the patch state that caused it", {
+  # The #571 reproducer. The refiner can only report a narrow feature in a
+  # function; the patch knows that the function is a light profile over a set of
+  # cohort heights, and that here the node list has lost its decreasing-height
+  # ordering -- which is what puts the fictitious step in the profile, because
+  # Species::compute_competition() early-exits on the first node below the query
+  # height and so drops the taller, and only living, cohort beyond it.
+  env <- Environment("TF24")
+  env$set_soil_number_of_depths(5)
+  env$set_soil_water_state(rep(0.005, 5))
+  env$extrinsic_drivers_set_constant("rainfall", 1)
+
+  p <- scm_base_parameters("TF24")
+  p$max_patch_lifetime <- 10
+  p <- add_strategies(p, trait_matrix(0.0825, "lma"))
+
+  msg <- tryCatch({
+    run_scm(p, env, collect = TRUE)
+    NA_character_
+  }, error = conditionMessage)
+
+  skip_if(is.na(msg), "dry-start TF24 now completes; see #571")
+
+  expect_match(msg, "Patch state at that height")
+  expect_match(msg, "cohorts within")
+  # The ordering violation is the actionable part, so it must be reported rather
+  # than left to be rediscovered.
+  expect_match(msg, "node heights are NOT decreasing")
+  expect_match(msg, "height_max\\(\\) reports")
+})

--- a/tests/testthat/test-tf24-arid-corner.R
+++ b/tests/testthat/test-tf24-arid-corner.R
@@ -114,4 +114,11 @@ test_that("a failed light spline reports the patch state that caused it", {
   # than left to be rediscovered.
   expect_match(msg, "node heights are NOT decreasing")
   expect_match(msg, "height_max\\(\\) reports")
+  # And it must separate the two very different readings of that violation:
+  # zero-density nodes scrambling the quadrature grid (bookkeeping) versus live
+  # cohorts crossing (which would mean the characteristics themselves crossed,
+  # and the method of characteristics forbids that). Measured here it is the
+  # former, but assert that both counts are reported rather than pinning which.
+  expect_match(msg, "between two cohorts of non-zero density")
+  expect_match(msg, "nodes have zero density")
 })


### PR DESCRIPTION
Stacked on #570 — based on `fix/tf24-site-prediction-unblockers`, so the diff here is
just the one commit. Once #570 merges, GitHub retargets this to `develop` and the
branch gets updated.

Implements candidate (3) from #571: fail with a diagnosis rather than a resolution
complaint. No behaviour change outside the error paths.

## What it does

- `AdaptiveInterpolator` reports the interval it could not resolve and the jump
  across it, and throws a typed `refinement_failure` carrying that location.
- `Patch::compute_environment` catches it and adds what the cohorts are doing at
  that height — including whether the node list has lost its decreasing-height
  ordering, which is what `Species::compute_competition()` and `height_max()`
  silently assume.
- `util::format_double` for error messages, since `std::to_string`'s fixed six
  decimals print spacings below 1e-6 as `0.000000`.

## Why it was worth doing first

It contradicted #571's own Cause section on the first run — see
https://github.com/traitecoevo/plant/issues/571#issuecomment-5108656912 for the
measurements. The stall is at 15.6202 m, not the 0.392 m introduction height, and the
patch is not ungrown (92 cohorts, 0.42–15.80 m). The step the refiner dies on is an
artefact of the broken node ordering, not a physical feature of the profile.

Message on the reproducer:

```
... The target has a feature narrower than that spacing, at x = 15.6202: across
[15.6202, 15.6202] the target jumps from 0.978563 to 1 (14 interval(s) still
unresolved, over the domain [0, 15.6999]). Patch state at that height (time 9):
species 1: 1 of 93 cohorts within 0.001 m, spanning [15.6202, 15.6202]; node heights
are NOT decreasing (18 inversions), which breaks the ordering that
Species::compute_competition() and height_max() assume: the tallest cohort is
15.8029 but height_max() reports 15.6999 (the front node), so the competition
profile is wrong and its steps are an artefact rather than a feature of the model;
```

## Tests

Three additions to `test-tf24-arid-corner.R`: the refiner names the stall location
for a step target; the SCM reproducer reports the patch state and the ordering
violation (skips if the dry start ever starts completing). Full suite green,
2548 pass / 0 fail.

Does **not** fix #571 — the ordering dependence and the degenerate size distribution
both remain. Fix order is revised in the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)