### PR TITLE
Build the competition profile over a sorted node grid when heights invert (#571)

### DIFF
--- a/inst/include/plant/species.h
+++ b/inst/include/plant/species.h
@@ -35,7 +35,6 @@ public:
   // ODE plumbing and the per-element serialisers are inherited from SpeciesBase
   // and iterate all nodes (the deterministic model has no notion of "dead").
   using base_type::ode_size;
-  using base_type::set_ode_state;
   using base_type::ode_state;
   using base_type::ode_rates;
   using base_type::get_node_state;
@@ -62,7 +61,17 @@ public:
   // twice was measurably slower on FF16 (~5% on the SCM benchmark) than the
   // O(1) nodes.front() it replaced.
   struct HeightScan { double h_max; bool decreasing; };
+  // Cached: heights change only when the ODE state is set or a node is
+  // introduced/cleared, whereas compute_competition() is called once per spline
+  // knot, so this is hundreds of calls per change. Every mutator invalidates.
   HeightScan scan_heights() const;
+
+  // Setting the ODE state rewrites every node's height, so the cached scan goes
+  // with it. Shadows (rather than uses) the SpeciesBase version for that reason.
+  odelia::ode::const_iterator set_ode_state(odelia::ode::const_iterator it) {
+    invalidate_height_scan();
+    return base_type::set_ode_state(it);
+  }
   void compute_rates(const environment_type& environment, double pr_patch_survival, double birth_rate);
   std::vector<double> net_reproduction_ratio_by_node() const;
   // Per-node lifetime offspring, weighted by patch-age density and S_D.
@@ -133,6 +142,16 @@ private:
   // ordered, so the node list cannot be used directly as the quadrature grid.
   double compute_competition_unordered(double height) const;
 
+  // Cache for scan_heights(). Every path that can change a node height must call
+  // invalidate_height_scan(); a stale cache here would silently reintroduce the
+  // wrong competition profile of #571, so the coverage of these calls was checked
+  // by asserting cache == freshly-computed on every call across the whole suite
+  // and the scenario gateway.
+  HeightScan compute_height_scan() const;
+  void invalidate_height_scan() { height_scan_valid = false; }
+  mutable HeightScan height_scan_cache{0.0, true};
+  mutable bool height_scan_valid = false;
+
   // Storage (strategy, nodes) and control() live in SpeciesBase; the
   // using-declarations let the unqualified references below resolve through the
   // dependent base.
@@ -158,6 +177,7 @@ size_t Species<T,E>::size() const {
 
 template <typename T, typename E>
 void Species<T,E>::clear() {
+  invalidate_height_scan();
   nodes.clear();
   // Reset the new_node to a blank new_node, too.
   new_node = node_type(strategy);
@@ -165,6 +185,7 @@ void Species<T,E>::clear() {
 
 template <typename T, typename E>
 void Species<T,E>::introduce_new_node() {
+  invalidate_height_scan();
   // new_node already holds the initial conditions computed against the current
   // environment by the most recent compute_rates() call (see compute_rates ->
   // new_node.compute_initial_conditions above), and the member is refreshed
@@ -209,9 +230,18 @@ bool Species<T,E>::heights_are_decreasing() const {
   return scan_heights().decreasing;
 }
 
-// Tallest height and orderedness in one pass over the heights.
 template <typename T, typename E>
 typename Species<T,E>::HeightScan Species<T,E>::scan_heights() const {
+  if (!height_scan_valid) {
+    height_scan_cache = compute_height_scan();
+    height_scan_valid = true;
+  }
+  return height_scan_cache;
+}
+
+// Tallest height and orderedness in one pass over the heights.
+template <typename T, typename E>
+typename Species<T,E>::HeightScan Species<T,E>::compute_height_scan() const {
   HeightScan ret{-std::numeric_limits<double>::infinity(), true};
   double h_prev = std::numeric_limits<double>::infinity();
   for (nodes_const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
@@ -362,6 +392,7 @@ void Species<T,E>::compute_rates(const E& environment, double pr_patch_survival,
 
 template <typename T, typename E>
 void Species<T,E>::introduce_new_node(double time, double patch_density) {
+  invalidate_height_scan();
   // Stamp the pushed copy (not new_node) so the member stays pristine for
   // the no-arg introduction paths.
   nodes.push_back(new_node);
@@ -489,6 +520,7 @@ std::vector<double> Species<T,E>::r_heights_rev() const {
 
 template <typename T, typename E>
 void Species<T,E>::r_set_heights(std::vector<double> heights) {
+  invalidate_height_scan();
   util::check_length(heights.size(), size());
   if (!util::is_decreasing(heights.begin(), heights.end())) {
     util::stop("height must be decreasing (ties allowed)");

--- a/inst/include/plant/species.h
+++ b/inst/include/plant/species.h
@@ -3,6 +3,9 @@
 #define SPECIES
 
 #include <vector>
+#include <algorithm>
+#include <limits>
+#include <utility>
 #include <plant/util.h>
 #include <plant/environment.h>
 #include <odelia/ode_interface.hpp>
@@ -51,6 +54,15 @@ public:
 
   double height_max() const;
   double compute_competition(double height) const;
+  // Whether the decreasing-height node ordering still holds (see height_max()).
+  bool heights_are_decreasing() const;
+
+  // The tallest node height and whether the heights are ordered, from a single
+  // pass. compute_competition() needs both on every call, and walking the heights
+  // twice was measurably slower on FF16 (~5% on the SCM benchmark) than the
+  // O(1) nodes.front() it replaced.
+  struct HeightScan { double h_max; bool decreasing; };
+  HeightScan scan_heights() const;
   void compute_rates(const environment_type& environment, double pr_patch_survival, double birth_rate);
   std::vector<double> net_reproduction_ratio_by_node() const;
   // Per-node lifetime offspring, weighted by patch-age density and S_D.
@@ -117,6 +129,10 @@ public:
   ExtrinsicDrivers extrinsic_drivers() const {return strategy->extrinsic_drivers;}
 
 private:
+  // compute_competition() for the case where the node heights are no longer
+  // ordered, so the node list cannot be used directly as the quadrature grid.
+  double compute_competition_unordered(double height) const;
+
   // Storage (strategy, nodes) and control() live in SpeciesBase; the
   // using-declarations let the unqualified references below resolve through the
   // dependent base.
@@ -161,11 +177,54 @@ void Species<T,E>::introduce_new_node() {
 
 // If a species contains no individuals, we return the height of a
 // seed of the species.  Otherwise we return the height of the largest
-// individual (always the first in the list) which will be at least
-// tall as a seed.
+// individual, which will be at least as tall as a seed.
+//
+// This used to return nodes.front(), relying on the decreasing-height ordering
+// asserted below. That ordering is guaranteed only while height growth is a
+// function of height and the shared environment, which TF24 broke: its
+// reserve-gated growth (#517) makes dh/dt depend on a cohort's own storage, so
+// two cohorts born moments apart into a rapidly changing environment can cross
+// in height. When they had, this returned a height 0.1 m *below* the tallest and
+// only living cohort, truncating the light spline's domain (#571). Scanning is
+// O(n) in heights only -- negligible against the crown integrals in
+// compute_competition -- and returns exactly nodes.front() whenever the ordering
+// does hold, so results are unchanged in that case.
 template <typename T, typename E>
 double Species<T,E>::height_max() const {
-  return nodes.empty() ? new_node.height() : nodes.front().height();
+  if (nodes.empty()) {
+    return new_node.height();
+  }
+  double ret = -std::numeric_limits<double>::infinity();
+  for (nodes_const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    ret = std::max(ret, it->height());
+  }
+  return ret;
+}
+
+// Are the node heights still ordered largest to smallest? See height_max() above
+// for why this can no longer be assumed. Heights only, so this is cheap relative
+// to the per-node crown integrals it guards.
+template <typename T, typename E>
+bool Species<T,E>::heights_are_decreasing() const {
+  return scan_heights().decreasing;
+}
+
+// Tallest height and orderedness in one pass over the heights.
+template <typename T, typename E>
+typename Species<T,E>::HeightScan Species<T,E>::scan_heights() const {
+  HeightScan ret{-std::numeric_limits<double>::infinity(), true};
+  double h_prev = std::numeric_limits<double>::infinity();
+  for (nodes_const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    const double h = it->height();
+    if (h > h_prev) {
+      ret.decreasing = false;
+    }
+    if (h > ret.h_max) {
+      ret.h_max = h;
+    }
+    h_prev = h;
+  }
+  return ret;
 }
 
 // Because of nodes are always ordered from largest to smallest, we
@@ -195,8 +254,22 @@ double Species<T,E>::height_max() const {
 // the integral).
 template <typename T, typename E>
 double Species<T,E>::compute_competition(double height) const {
-  if (size() == 0 || height_max() < height) {
+  if (size() == 0) {
     return 0.0;
+  }
+  const HeightScan scan = scan_heights();
+  if (scan.h_max < height) {
+    return 0.0;
+  }
+  // The loop below uses the node list itself as the quadrature grid, and the
+  // early exit is valid only if that grid is monotone. When it is not, the exit
+  // fires at the first node below `height` and silently drops every node beyond
+  // it -- including, in #571, the only cohort with non-zero density, which put a
+  // fictitious step in the competition profile. Take the ordered path instead.
+  // Heights only, so the usual (ordered) case keeps this loop and its results
+  // exactly.
+  if (!scan.decreasing) {
+    return compute_competition_unordered(height);
   }
   double tot = 0.0;
   nodes_const_iterator it = nodes.begin();
@@ -216,6 +289,57 @@ double Species<T,E>::compute_competition(double height) const {
     if (h0 < height) {
       break;
     }
+  }
+
+  if (size() == 1 || f_h1 > 0) {
+    const double h0 = new_node.height(), f_h0 = new_node.compute_competition(height);
+    tot += (h1 - h0) * (f_h1 + f_h0);
+  }
+
+  return tot / 2;
+}
+
+// The same trapezium integral as compute_competition(), but over a height-sorted
+// view of the nodes rather than the node list in place. Used only when the
+// ordering has broken (#571): it agrees with the in-place version whenever the
+// ordering holds, so this is a fallback rather than a change of method.
+//
+// Dropping the zero-density nodes instead would be wrong. A node whose density
+// has collapsed to exactly zero contributes f = 0, and that zero is meaningful --
+// it is the reconstruction saying density vanishes at that size. Removing those
+// grid points would interpolate live density straight across the band and
+// overestimate it, so they stay in and the grid gets sorted.
+//
+// No early exit here: it would need the same monotonicity that is missing. Nodes
+// below `height` contribute f = 0 at both ends, so including them costs time but
+// changes nothing. The scratch buffer is thread_local and reused, so the repeated
+// calls that build one spline do not each allocate.
+template <typename T, typename E>
+double Species<T,E>::compute_competition_unordered(double height) const {
+  thread_local std::vector<std::pair<double, double>> hf;
+  hf.clear();
+  hf.reserve(size());
+
+  for (nodes_const_iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    const double f = it->compute_competition(height);
+    if (!util::is_finite(f)) {
+      util::stop("Detected non-finite contribution");
+    }
+    hf.push_back({it->height(), f});
+  }
+  std::sort(hf.begin(), hf.end(),
+            [](std::pair<double, double> const& a,
+               std::pair<double, double> const& b) {
+              return a.first > b.first;
+            });
+
+  double tot = 0.0;
+  double h1 = hf.front().first, f_h1 = hf.front().second;
+  for (size_t j = 1; j < hf.size(); ++j) {
+    const double h0 = hf[j].first, f_h0 = hf[j].second;
+    tot += (h1 - h0) * (f_h1 + f_h0);
+    h1   = h0;
+    f_h1 = f_h0;
   }
 
   if (size() == 1 || f_h1 > 0) {

--- a/tests/testthat/test-tf24-arid-corner.R
+++ b/tests/testthat/test-tf24-arid-corner.R
@@ -85,13 +85,68 @@ test_that("a resolution limit says where refinement stalled", {
   expect_match(msg, "interval\\(s\\) still unresolved")
 })
 
+## Helper: the #571 dry start. Five layers held below the residual floor with
+## 1 m/yr rainfall, which is a normal dryland initial condition rather than an
+## edge case (Dahra is 416 mm MAP).
+tf24_dry_start <- function(model = "TF24", lifetime = 10) {
+  env <- Environment(model)
+  env$set_soil_number_of_depths(5)
+  env$set_soil_water_state(rep(0.005, 5))
+  env$extrinsic_drivers_set_constant("rainfall", 1)
+
+  p <- scm_base_parameters(model)
+  p$max_patch_lifetime <- lifetime
+  p <- add_strategies(p, trait_matrix(0.0825, "lma"))
+  list(p = p, env = env)
+}
+
+test_that("height_max() is the tallest cohort, not the first node (#571)", {
+  # Under water limitation the top of the size distribution converges into a band
+  # narrower than the refiner's finest spacing, and cohorts in it cross: TF24's
+  # reserve-gated growth (#517) makes dh/dt depend on a cohort's own storage, so
+  # two cohorts born moments apart into a rapidly wetting soil need not stay in
+  # size order. That breaks the decreasing-height ordering that height_max() used
+  # to exploit by returning nodes.front(), which then reported a height *below*
+  # the tallest and only living cohort and truncated the light spline's domain.
+  x <- tf24_dry_start()
+  scm <- SCM("TF24", "TF24_Env")(x$p, x$env, Control())
+  scm$run()
+
+  sp <- scm$patch$species[[1]]
+  h <- sp$heights
+
+  # The premise of the test: this state really does violate the ordering. If a
+  # future change makes the size distribution well-behaved, this stops being the
+  # case that needs guarding and the assertions below become vacuous.
+  skip_if(all(diff(h) <= 0), "node heights no longer invert here; see #571")
+
+  expect_equal(sp$height_max, max(h))
+  expect_gt(max(h), h[1])       # i.e. the front node is *not* the tallest
+})
+
+test_that("a dry-start TF24 run completes (#571)", {
+  # Was: died in the light spline, because compute_competition()'s early exit
+  # dropped every node past the first one below the query height -- including the
+  # one cohort with appreciable density -- putting a fictitious step in the
+  # competition profile that the refiner could not resolve.
+  x <- tf24_dry_start()
+  out <- run_scm(x$p, x$env, collect = TRUE)
+  expect_true(is.finite(out$offspring_production))
+
+  # The whole non-monotone failure set recorded in #571, which ruled out any
+  # single threshold as the cause.
+  for (theta in c(0.005, 0.008, 0.0099, 0.010, 0.0101, 0.012, 0.015, 0.02, 0.03)) {
+    y <- tf24_dry_start()
+    y$env$set_soil_water_state(rep(theta, 5))
+    expect_no_error(run_scm(y$p, y$env, collect = FALSE))
+  }
+})
+
 test_that("a failed light spline reports the patch state that caused it", {
-  # The #571 reproducer. The refiner can only report a narrow feature in a
-  # function; the patch knows that the function is a light profile over a set of
-  # cohort heights, and that here the node list has lost its decreasing-height
-  # ordering -- which is what puts the fictitious step in the profile, because
-  # Species::compute_competition() early-exits on the first node below the query
-  # height and so drops the taller, and only living, cohort beyond it.
+  # The refiner can only report a narrow feature in a function; the patch knows
+  # that the function is a light profile over a set of cohort heights. Kept as a
+  # guard on the message: the reproducer no longer fails, so this asserts the
+  # diagnosis is present *if* a resolution failure ever comes back.
   env <- Environment("TF24")
   env$set_soil_number_of_depths(5)
   env$set_soil_water_state(rep(0.005, 5))


### PR DESCRIPTION
Now targets `develop` directly — #570, #573 and #580 have all merged, and this is rebased onto
them (two commits, two files). **This is the fix for the crash in #571**; #573 was the
diagnostic that found the real cause.

## The bug

`Species::compute_competition()` uses the node list itself as the quadrature grid for the
trapezium integral over the size axis, and `Species::height_max()` returned `nodes.front()`.
Both rely on nodes being ordered largest to smallest.

That ordering used to be free. With `dh/dt` a function of height and the shared environment,
growth trajectories cannot cross, so cohorts introduced in order stay in order — which is why it
was asserted in a comment rather than maintained.

**TF24 broke it.** Reserve-gated growth (#517) makes `dh/dt` depend on a cohort's own storage, so
two cohorts born moments apart into a rapidly wetting soil start from different operating points
and the later one can overtake. Measured on the #571 dry start: introduction times strictly
increasing (0.0195 → 0.0234) but final heights *not* (15.6202 → 15.6716). 18 inversions, and
`height_max()` reporting 14.9385 when the tallest — and only living — cohort is at 14.9691.

Consequences: a light spline truncated 0.03–0.10 m below the tallest plant, and an early exit
firing at the first node below the query height that dropped every node past it, including the
one cohort with appreciable density. That is the fictitious step the refiner was dying on.

## The fix

One fused `scan_heights()` pass per call gets both the tallest height and whether the heights are
ordered; when they are not, fall back to the same trapezium integral over a height-sorted view.

Zero-density nodes deliberately stay in the integral. `f = 0` at such a node is the
reconstruction saying density vanishes at that size; dropping those grid points would interpolate
live density straight across the band and overestimate it. So the grid gets sorted, not filtered.

The scan is cached and invalidated by the paths that can change a height (`set_ode_state` — now
shadowed rather than inherited — both `introduce_new_node` overloads, `clear()`,
`r_set_heights()`), because `compute_competition()` is called once per spline knot, i.e. hundreds
of calls between two changes to those heights.

Gating instead on *"a node was introduced at zero density"* was considered and rejected: density
never enters the height ODE, so a zero-density node is not what makes cohorts cross —
state-dependent growth is. The two are correlated in the #571 patch only because the inert
cohorts happen to be the ones bunched at the ceiling. Using density as the trigger would restore
the silent wrongness for the one case that cannot be ruled out, two *live* cohorts crossing.

## Verification

- **Equivalent, not a change of method.** Forcing the sorted path for *every* call in *every*
  model leaves the full suite and the TF24 scenario gateway passing. The early exit is a pure
  optimisation, so the ordered case is unchanged and only states that were previously wrong move.
- **No cache staleness.** With a temporary assertion that the cached scan always equals a freshly
  computed one, the full suite and the gateway pass with none detected — so the invalidation
  coverage is measured, not assumed. That mattered because a stale cache would silently
  reintroduce exactly the profile this PR fixes.
- **No baseline re-bless needed.** `PLANT_RUN_SCENARIOS=1` gateway passes against the blessed
  scorecard; TF24 bench `offspring_production` unchanged at `0.0001899296527`.
- **The crash is gone.** All nine θ₀ values recorded as failing in #571 run, and a 94-configuration
  sweep across all four axes of that issue's failure table (θ₀ 0–0.428, layers 1–20, rainfall 0–2,
  lifetimes 2–30, both TF24 and TF24f) reports no resolution failure anywhere.
- Suite green at 2556 pass / 0 fail after the rebase onto current `develop`.

Tests: `height_max()` equals the tallest cohort while the front node does not (the precise
regression), the dry start completes, and the whole non-monotone θ₀ failure set runs. Both new
tests `skip_if` the pathological state stops occurring, so they cannot silently become vacuous.

## Cost

The scan replaces an `O(1)` `nodes.front()`. Cached, it is within noise of baseline; uncached and
fused it was +2.5% / +2.7%, and as two separate passes twice that (interleaved A/B, sampling off,
per `profile-plant`).

| state | scm 20-rep (s) | build_schedule 20-rep (s) |
|---|---|---|
| before | 2.042 / 2.056 / 2.091 | 5.883 / 5.850 / 5.997 |
| uncached scan | 2.123 / 2.076 | 5.999 / 6.054 |
| **cached scan** | **2.023 / 2.028** | **5.796 / 5.814** |

## What this does *not* fix

- **#576** — one dry TF24f configuration (rainfall 0.04–0.05) still fails, with a *different*
  mechanism: a hydraulic spline evaluated outside its domain in `leaf_model.cpp`. So "TF24f cannot
  crash when dry" is not yet true.
- A latent numerics tension: characteristics legitimately converge to within ~2.6e-5 m near a
  water-limited ceiling, against the light refiner's 1.5e-5 m floor. This PR makes the integral
  correct regardless of ordering, so it is latent rather than removed.

Note #575 (zero-density cohorts) was **closed as invalid** — that behaviour is the method of
characteristics working as designed, per Daniel's correction; see
[plant-meta#3](https://github.com/traitecoevo/plant-meta/pull/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
