### PR TITLE
Point agents.md at the family model-robustness rule

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -732,3 +732,11 @@ org — a hub-and-spoke set of packages built around the
   work is tracked on [board #5](https://github.com/orgs/traitecoevo/projects/5) (new issues
   auto-add with no Status = the triage queue). Labels: `bug` / `task` / `epic` plus `blocked`,
   `needs-info`, `cross-package`, `breaking`, `question`.
+- **What should run vs. what should fail** — strategies and environments are expected to run
+  across a wide range of trait values and conditions and give sensible biological outputs
+  (including zero growth or reproduction) rather than crash; a *physically unrealistic* state
+  should fail, naming the quantity, its value and the constraint violated. Read
+  [`model-robustness.md`](https://github.com/traitecoevo/plant-meta/blob/main/governance/model-robustness.md)
+  before adding or removing a guard in a strategy, environment or numerical routine — it has the
+  decision rule, and the traps (a guard returning a plausible number is worse than a crash; a
+  state that can only be *inferred* from the outputs is not disclosed).


### PR DESCRIPTION
Follow-up to [traitecoevo/plant-meta#2](https://github.com/traitecoevo/plant-meta/pull/2)
(merged): plant's `agents.md` should point at the new family rule, since plant is where the
guards actually get written.

One bullet in the existing **Plant family** pointer block:

> **What should run vs. what should fail** — strategies and environments are expected to run
> across a wide range of trait values and conditions and give sensible biological outputs
> (including zero growth or reproduction) rather than crash; a *physically unrealistic* state
> should fail, naming the quantity, its value and the constraint violated.

Worded to be read *before adding or removing a guard*, which is when it matters and is where the
[#570 review discussion](https://github.com/traitecoevo/plant/pull/570#discussion_r3670955282)
started. It also flags the two traps the doc spends most of its length on: a guard returning a
plausible number is worse than a crash, and a state that can only be *inferred* from the outputs
is not disclosed.

Docs only — no code, no tests affected. Independent of #570/#573/#574 (none of them touch
`agents.md`), so it can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)