### PR TITLE
Don't ask for a gradient in hydraulic shutdown

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -309,6 +309,32 @@ were not previously recorded here:
 
 ### Minor changes & bug fixes
 
+* **TF24f no longer asks for an acclimation gradient in hydraulic shutdown**
+  (#576). In a narrow dry rainfall window (0.04–0.05 m/yr at θ = 0.005, five
+  layers) TF24f died with "Extrapolation disabled and evaluation point outside of
+  interpolated domain" while TF24 ran. The cause was an asymmetry between the two
+  gradient methods in `TF24f_Strategy::solve_leaf`, not a numerical limit: the
+  finite-difference branch checked `prepare_collar_solve()`'s return value and
+  took a zero gradient when the operating point had been *forced* by feasibility
+  handling, while the AD branch called `evaluate_root_collar_psi()` — which hides
+  that return value — and then asked for a gradient regardless. In shutdown the
+  collar potential is set to `-root_psi_crit`, where soil uptake is negative, so
+  the stem potential that would carry it is wetter than saturation and the
+  transport inverse genuinely has no solution. The out-of-domain error was
+  correct; the question was wrong. The AD branch now mirrors the FD branch, which
+  also drops a redundant re-derivation of the soil-side caches per step. Behaviour
+  changes only in states that previously threw, so the TF24f scientific version
+  does not move.
+* **The leaf hydraulic transport splines say which spline, point and domain
+  failed** (#576). `transpiration_from_psi` and `psi_from_transpiration` are the
+  only interpolators in `leaf_model.cpp` with extrapolation disabled, and odelia's
+  out-of-domain error names none of the three, so localising #576 meant bisecting
+  four call sites by hand. Lookups now report the spline, the evaluation point,
+  how far outside it fell and which call was asking; a non-finite point is
+  reported as such rather than as a too-narrow domain (the misdirection #573
+  removed from the adaptive interpolator). Failures inside the collar solve also
+  carry the bracket they were working within and which feasibility branch
+  `prepare_collar_solve()` exited through.
 * **The TF24 rainfall driver is floored at zero.** Because drivers are
   interpolated with a cubic spline, an intermittent series undershoots below
   every supplied value, and negative rainfall gave negative infiltration and an

--- a/inst/include/plant/leaf_model.h
+++ b/inst/include/plant/leaf_model.h
@@ -13,6 +13,9 @@
 #include <plant/uniroot.h>
 #include <plant/optimize.h>
 
+#include <limits>
+#include <string>
+
 namespace plant {
 
 // double check best namespace for constants (private vs global)
@@ -307,6 +310,20 @@ public:
   // false when the operating point is already fully determined (caller is done),
   // true when there is a real interval to choose a collar potential within.
   bool prepare_collar_solve(double& bound_a, double& bound_b);
+  // The two collar potentials prepare_collar_solve derived the feasible interval
+  // from (signed, <= 0), kept so a failure anywhere downstream of it can say
+  // which bracket it was working inside -- see collar_solve_context(). Only
+  // meaningful for the step whose prepare_collar_solve most recently ran.
+  double root_crit_ = std::numeric_limits<double>::quiet_NaN();
+  double root_zero_E_ = std::numeric_limits<double>::quiet_NaN();
+  // Which feasibility branch prepare_collar_solve exited through, or nullptr if
+  // it returned a real interval. Reported by collar_solve_context(), and the
+  // reason a caller can tell "the operating point was chosen by the optimiser"
+  // from "the operating point was forced by shutdown".
+  const char* collar_exit_ = nullptr;
+  // Human-readable dump of the collar-solve bracket and the soil state it came
+  // from, appended to errors raised inside the solve (#576).
+  std::string collar_solve_context() const;
   // Evaluate the leaf at a *given* root-collar potential (positive magnitude)
   // rather than optimising it: reuses prepare_collar_solve, clamps the target to
   // the feasible interval, and evaluates there (no golden-section search). Leaves

--- a/src/leaf_model.cpp
+++ b/src/leaf_model.cpp
@@ -24,6 +24,39 @@ template <typename T>
 T hydraulic_cost_ad(T psi_stem, double b, double c, double g1, double beta2) {
   return g1 * pow(1.0 - exp(-pow(psi_stem / b, c)), beta2);
 }
+
+// Domain-guarded lookup on the two xylem transport splines, which are the only
+// interpolators in this file built with extrapolation DISABLED (the root
+// vulnerability pair clamps instead -- see setup_root_vulnerability). odelia's
+// own out-of-domain error is a bare sentence naming neither the spline, the
+// point, nor the domain, which made #576 a bisect instead of a read. One
+// comparison on a path that already does a spline solve.
+double eval_in_domain(const odelia::interpolator::Interpolator& spline, double u,
+                      const char* spline_name, const char* arg_name,
+                      const std::string& context = std::string()) {
+  const double lo = spline.min();
+  const double hi = spline.max();
+  // Deliberately the SAME condition as odelia's own check, not the negation of
+  // an in-range test: every comparison against NaN is false, so a non-finite u
+  // falls through here exactly as it did before and reaches the spline. That is
+  // load-bearing rather than an oversight -- Leaf::profit_psi_stem_TF(NA, ...)
+  // is documented (test-leaf.r) to return NA, and the non-finite value is caught
+  // downstream by the isfinite(profit_) guards in the collar solve, which report
+  // far more context than this lookup could. Writing `!(u >= lo && u <= hi)`
+  // here instead turns that into a throw and is a behaviour change well beyond
+  // the reporting fix this function exists for.
+  if (u < lo || u > hi) {
+    const bool below = u < lo;
+    util::stop(std::string("Leaf hydraulics: ") + spline_name +
+               " evaluated outside its domain: " + arg_name + " = " +
+               util::format_double(u) + " lies " +
+               util::format_double(below ? lo - u : u - hi) + " beyond the " +
+               (below ? "lower" : "upper") + " end of [" +
+               util::format_double(lo) + ", " + util::format_double(hi) + "]" +
+               (context.empty() ? std::string() : "; " + context) + ".");
+  }
+  return spline.eval(u);
+}
 }  // namespace
 Leaf::Leaf()
     :
@@ -621,6 +654,37 @@ double Leaf::find_root_psi(double wettest_soil_layer, const std::vector<double>&
 
 }
 
+// Bracket and soil state the current collar solve is working inside. Appended to
+// failures raised beneath find_root_collar_psi, because those failures are
+// almost always a property of the bracket rather than of the point that tripped
+// them (#576): the collar potential handed to the transport is chosen from
+// [root_zero_E_, root_crit_], so an out-of-domain psi_stem is a statement about
+// where those two ended up.
+std::string Leaf::collar_solve_context() const {
+  std::string out =
+      std::string(collar_exit_ ? std::string("prepare_collar_solve exited via: ") +
+                                     collar_exit_ + "; "
+                               : std::string("prepare_collar_solve returned a real interval; ")) +
+      "collar bracket: root_zero_E=" + util::format_double(root_zero_E_) +
+      ", root_crit=" + util::format_double(root_crit_) +
+      " (signed potentials); psi_crit=" + util::format_double(psi_crit) +
+      ", root_psi_crit=" + util::format_double(root_psi_crit);
+  // root_crit pinned to the bracket's dry endpoint means find_root_psi never
+  // found an interior continuity root and returned the endpoint it was handed,
+  // so the "feasible" interval reaches a collar potential at which the stem
+  // cannot balance. Worth saying explicitly; it is the #576 signature.
+  if (std::isfinite(root_crit_) &&
+      std::abs(-root_crit_ - psi_crit) < 1e-4 * std::max(1.0, psi_crit)) {
+    out += "; root_crit is AT the dry endpoint -psi_crit (within 1e-4), i.e. the "
+           "continuity solve returned its bracket end rather than an interior root";
+  }
+  out += "; psi_soil (signed, by layer) =";
+  for (size_t i = 0; i < psi_soil_inverted_.size(); ++i) {
+    out += (i ? ", " : " ") + util::format_double(psi_soil_inverted_[i]);
+  }
+  return out;
+}
+
 // When root pressure is known, find E from soil, then use E from soil to find psi stem
 double Leaf::find_psi_stem_from_psi_root(double psi_root, const std::vector<double>& psi_soil){
   E_from_Soil_to_Root_Collar(psi_root, psi_soil);
@@ -702,6 +766,10 @@ void Leaf::set_shutdown_state(double root_collar) {
 // collar-potential interval (positive magnitudes) otherwise.
 bool Leaf::prepare_collar_solve(double& bound_a, double& bound_b){
 
+  collar_exit_ = nullptr;
+  root_crit_ = std::numeric_limits<double>::quiet_NaN();
+  root_zero_E_ = std::numeric_limits<double>::quiet_NaN();
+
   // psi_soil_ arrives as positive magnitudes; flip once to the signed (negative)
   // potential convention used throughout the soil->collar transport (see the
   // sign-conventions block above E_from_Soil_to_Root_Collar).
@@ -723,6 +791,7 @@ bool Leaf::prepare_collar_solve(double& bound_a, double& bound_b){
   // shut down
 
   if (-wettest_soil_layer >= psi_crit){
+    collar_exit_ = "shutdown: wettest soil layer is drier than psi_crit";
     set_shutdown_state(-psi_crit);
     return false;
   }
@@ -730,6 +799,8 @@ bool Leaf::prepare_collar_solve(double& bound_a, double& bound_b){
 if(E_column(-psi_crit, psi_soil_inverted_, psi_crit) < 0){
       // root_collar_psi_ is reported as a signed (negative) potential, so store
       // -root_psi_crit rather than the positive magnitude root_psi_crit.
+      collar_exit_ = "shutdown: E_column(-psi_crit) < 0, soil cannot supply the "
+                     "flux demanded even at psi_crit";
       set_shutdown_state(-root_psi_crit);
       return false;
 }
@@ -737,19 +808,23 @@ if(E_column(-psi_crit, psi_soil_inverted_, psi_crit) < 0){
   // Avoid loop if the wettest psi layer is drier than psi_crit in stem, transpiration not possible and so all variables set to
   // shut down
 double root_crit = find_root_psi(wettest_soil_layer, psi_soil_inverted_, 1);
+root_crit_ = root_crit;
 
 // If root crit would have to be larger than psi crit, also avoid loop as above
 
     if (-root_crit >= psi_crit){
+    collar_exit_ = "shutdown: continuity root would need the collar drier than psi_crit";
     set_shutdown_state(root_crit);
     return false;
   }
 
 // Find root collar where transpiration from soil is 0
 double root_zero_E = find_root_psi(wettest_soil_layer, psi_soil_inverted_, 0);
+root_zero_E_ = root_zero_E;
 
 // If assimilation would be less than 0 even at Ca, also end loop
 if(assim_max_ < 0){
+    collar_exit_ = "assimilation negative even at ci = ca";
     // At zero transpiration the stem equilibrates with the collar (no flux, no
     // gradient), so the operating point is root_zero_E for both. root_collar_psi_
     // is the signed (negative) potential (#7); opt_psi_stem_ is the matching
@@ -787,8 +862,21 @@ if(assim_max_ < 0){
     // If no interval exists (single feasible root-collar value), use that
     // point directly as the alternative solution instead of running GSS.
     if (std::abs(bound_b - bound_a) <= GSS_tol_abs) {
+      collar_exit_ = "collapsed feasible interval (single feasible collar potential)";
       const double opt_root_psi = 0.5 * (bound_a + bound_b);
-      const double psi_stem_single = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
+      double psi_stem_single;
+      try {
+        psi_stem_single = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
+      } catch (const std::exception& e) {
+        util::stop(std::string(e.what()) +
+                   " [collapsed collar interval: bound_a=" +
+                   util::format_double(bound_a) + ", bound_b=" +
+                   util::format_double(bound_b) + " differ by less than "
+                   "GSS_tol_abs=" + util::format_double(GSS_tol_abs) +
+                   ", so the single feasible collar potential " +
+                   util::format_double(opt_root_psi) + " was used directly; " +
+                   collar_solve_context() + "]");
+      }
 
       if (!std::isfinite(psi_stem_single)) {
         util::stop("Error: non-finite psi_stem_single in collapsed-root interval; "
@@ -830,29 +918,37 @@ void Leaf::find_root_collar_psi(){
     if (!prepare_collar_solve(bound_a, bound_b)) {
       return;
     }
-    // root_crit / root_zero_E were consumed inside prepare_collar_solve; recover
-    // them for the diagnostic message only if the profit check below fails.
-
     // Maximise carbon profit over the feasible collar-potential interval via
     // golden-section search (util::golden_section_max). Unlike Brent, its argmax
     // is a smooth (fixed-iteration) function of the inputs, so the operating
     // point varies smoothly with plant height -- the demographic growth-rate
     // gradient relies on this. The objective maps a candidate collar potential
     // `bound` to its profit (find the stem psi it implies, then evaluate profit).
-    const double opt_root_psi = util::golden_section_max(
-        [&](double bound) {
-          const double psi_stem =
-              find_psi_stem_from_psi_root(-bound, psi_soil_inverted_);
-          return profit_psi_stem_TF(psi_stem, bound);
-        },
-        bound_a, bound_b, GSS_tol_abs);
+    //
+    // Anything raised inside the search gets the bracket attached on the way out
+    // (#576): the collar potential is chosen from [bound_a, bound_b], so a
+    // failure at one candidate is a statement about the interval, and the
+    // interval is not visible from where the failure is thrown.
+    try {
+      const double opt_root_psi = util::golden_section_max(
+          [&](double bound) {
+            const double psi_stem =
+                find_psi_stem_from_psi_root(-bound, psi_soil_inverted_);
+            return profit_psi_stem_TF(psi_stem, bound);
+          },
+          bound_a, bound_b, GSS_tol_abs);
 
-    opt_psi_stem_ = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
+      opt_psi_stem_ = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
 
-    // store as the signed (negative) potential for a sign-consistent aux output;
-    // profit_psi_stem_TF takes psi_upstream as a positive magnitude.
-    root_collar_psi_ = -opt_root_psi;
-    profit_ = profit_psi_stem_TF(opt_psi_stem_, opt_root_psi);
+      // store as the signed (negative) potential for a sign-consistent aux output;
+      // profit_psi_stem_TF takes psi_upstream as a positive magnitude.
+      root_collar_psi_ = -opt_root_psi;
+      profit_ = profit_psi_stem_TF(opt_psi_stem_, opt_root_psi);
+    } catch (const std::exception& e) {
+      util::stop(std::string(e.what()) + " [collar solve over bound_a=" +
+                 util::format_double(bound_a) + ", bound_b=" +
+                 util::format_double(bound_b) + "; " + collar_solve_context() + "]");
+    }
 
     if(!std::isfinite(profit_)){
         util::stop("Error: non-finite profit; opt_psi_stem_=" + util::to_string(opt_psi_stem_) +
@@ -892,9 +988,21 @@ double Leaf::profit_at_collar_psi(double target_opt_root_psi,
     const double opt_root_psi =
         std::min(std::max(target_opt_root_psi, bound_a), bound_b);
 
-    opt_psi_stem_ = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
-    root_collar_psi_ = -opt_root_psi;
-    profit_ = profit_psi_stem_TF(opt_psi_stem_, opt_root_psi);
+    // As in find_root_collar_psi: attach the bracket the clamp drew from, since a
+    // failure here is a property of [bound_a, bound_b] and of where the tracked
+    // target sat relative to it, neither of which is visible downstream (#576).
+    try {
+      opt_psi_stem_ = find_psi_stem_from_psi_root(-opt_root_psi, psi_soil_inverted_);
+      root_collar_psi_ = -opt_root_psi;
+      profit_ = profit_psi_stem_TF(opt_psi_stem_, opt_root_psi);
+    } catch (const std::exception& e) {
+      util::stop(std::string(e.what()) +
+                 " [collar potential clamped to " +
+                 util::format_double(opt_root_psi) + " from tracked target " +
+                 util::format_double(target_opt_root_psi) + " over bound_a=" +
+                 util::format_double(bound_a) + ", bound_b=" +
+                 util::format_double(bound_b) + "; " + collar_solve_context() + "]");
+    }
 
     if(!std::isfinite(profit_)){
         util::stop("Error: non-finite profit in evaluate_root_collar_psi; "
@@ -923,7 +1031,14 @@ double Leaf::dprofit_droot_collar_psi(double opt_root_psi) {
   const double gstar_Pa = gamma_ * umol_per_mol_to_Pa;
 
   // Operating point in double.
-  const double psi_stem = find_psi_stem_from_psi_root(-psi, psi_soil_inverted_);
+  double psi_stem;
+  try {
+    psi_stem = find_psi_stem_from_psi_root(-psi, psi_soil_inverted_);
+  } catch (const std::exception& e) {
+    util::stop(std::string(e.what()) +
+               " [operating point in dprofit_droot_collar_psi(psi=" +
+               util::format_double(psi) + "); " + collar_solve_context() + "]");
+  }
   // Shut down before the ci solve, not after. psi and psi_stem are positive
   // magnitudes here, so psi >= psi_stem is the no-flow / reversed-gradient case
   // -- the same condition set_leaf_states_rates_from_psi_stem() treats as zero
@@ -984,15 +1099,29 @@ double Leaf::dprofit_droot_collar_psi(double opt_root_psi) {
   if (std::isfinite(dEup_dr)) {
     E_from_Soil_to_Root_Collar(r, psi_soil_inverted_);  // refresh E_up_ at r
     const double E_psi_stem =
-        E_up_ / leaf_specific_conductance_max_ + transpiration_from_psi.eval(psi);
+        E_up_ / leaf_specific_conductance_max_ +
+        eval_in_domain(transpiration_from_psi, psi,
+                       "transpiration_from_psi (cumulative xylem conductivity "
+                       "integral G(psi), psi in +MPa)",
+                       "psi", "in Leaf::dprofit_droot_collar_psi(psi=" +
+                                  util::format_double(psi) + ")");
     const double dEpsistem_dpsi =
         -dEup_dr / leaf_specific_conductance_max_ + transpiration_from_psi.deriv(psi);
     dpsistem_dpsi = psi_from_transpiration.deriv(E_psi_stem) * dEpsistem_dpsi;
   } else {
     const double h = 1e-6;
-    dpsistem_dpsi =
-        (find_psi_stem_from_psi_root(-(psi + h), psi_soil_inverted_) -
-         find_psi_stem_from_psi_root(-(psi - h), psi_soil_inverted_)) / (2.0 * h);
+    try {
+      dpsistem_dpsi =
+          (find_psi_stem_from_psi_root(-(psi + h), psi_soil_inverted_) -
+           find_psi_stem_from_psi_root(-(psi - h), psi_soil_inverted_)) / (2.0 * h);
+    } catch (const std::exception& e) {
+      util::stop(std::string(e.what()) +
+                 " [central difference on the transport in "
+                 "dprofit_droot_collar_psi, psi=" + util::format_double(psi) +
+                 " +/- h=" + util::format_double(h) +
+                 ", taken because dE_from_soil_dpsi_collar returned non-finite; " +
+                 collar_solve_context() + "]");
+    }
   }
 
   const double dci_dpsi = dci_dpsistem * dpsistem_dpsi + dci_dpsi_expl;
@@ -1179,8 +1308,16 @@ double Leaf::transpiration(double psi_stem, double psi_upstream) {
   }
 
   // integration of proportion_of_conductivity over [root_collar_psi_, psi_stem]
+  const std::string ctx = "in Leaf::transpiration(psi_stem=" +
+                          util::format_double(psi_stem) + ", psi_upstream=" +
+                          util::format_double(psi_upstream) + ")";
   const double E = leaf_specific_conductance_max_ *
-    (transpiration_from_psi.eval(psi_stem) - transpiration_from_psi.eval(psi_upstream));
+    (eval_in_domain(transpiration_from_psi, psi_stem,
+                    "transpiration_from_psi (cumulative xylem conductivity "
+                    "integral G(psi), psi in +MPa)", "psi_stem", ctx) -
+     eval_in_domain(transpiration_from_psi, psi_upstream,
+                    "transpiration_from_psi (cumulative xylem conductivity "
+                    "integral G(psi), psi in +MPa)", "psi_upstream", ctx));
   // return (transpiration_full_integration(psi_stem));
 
   transpiration_cache_psi_stem_ = psi_stem;
@@ -1198,10 +1335,23 @@ double Leaf::transpiration_to_psi_stem(double transpiration_, double psi_upstrea
   // integration of proportion_of_conductivity over [root_collar_psi_, psi_stem]
 
 
-  double E_psi_stem = transpiration_/leaf_specific_conductance_max_ +  transpiration_from_psi.eval(-psi_upstream);
+  const std::string ctx = "in Leaf::transpiration_to_psi_stem(transpiration=" +
+                          util::format_double(transpiration_) +
+                          ", psi_upstream=" + util::format_double(psi_upstream) +
+                          "); leaf_specific_conductance_max=" +
+                          util::format_double(leaf_specific_conductance_max_);
 
+  double E_psi_stem =
+      transpiration_ / leaf_specific_conductance_max_ +
+      eval_in_domain(transpiration_from_psi, -psi_upstream,
+                     "transpiration_from_psi (cumulative xylem conductivity "
+                     "integral G(psi), psi in +MPa)",
+                     "-psi_upstream", ctx);
 
-  return psi_from_transpiration.eval(E_psi_stem);
+  return eval_in_domain(psi_from_transpiration, E_psi_stem,
+                        "psi_from_transpiration (inverse of the cumulative "
+                        "xylem conductivity integral, G^-1)",
+                        "E/K_max + G(-psi_upstream)", ctx);
   }
 
 // returns stomatal conductance to CO2, mol C m^-2 LA s^-1

--- a/src/tf24f_strategy.cpp
+++ b/src/tf24f_strategy.cpp
@@ -58,12 +58,31 @@ void TF24f_Strategy::solve_leaf() {
     // Exact gradient (default, #527): forward-mode AD over the analytic algebra
     // + IFT at the ci root-find + analytic spline derivatives for the transport.
     // No O(h) bias and no finite-difference step to tune.
+    //
+    // Run prepare_collar_solve explicitly rather than letting
+    // evaluate_root_collar_psi hide it, for the same reason the FD branch below
+    // does: its return value is the only way to see that the operating point was
+    // forced by feasibility handling rather than chosen from an interval. When it
+    // was, there is no interval to move within, so the acclimation gradient is
+    // zero -- and asking for one is not merely wasted work, it is a question with
+    // no answer. In shutdown, root_collar_psi_ is set to -root_psi_crit, a collar
+    // potential at which the soil cannot supply the demanded flux at all; the
+    // uptake there is NEGATIVE, so the stem potential that would carry it is
+    // wetter than saturation and the transport inverse has no solution. That is
+    // what killed TF24f in the dry rainfall window of #576.
+    double bound_a, bound_b;
+    if (!leaf.prepare_collar_solve(bound_a, bound_b)) {
+      dprofit_dpsi_ = 0.0;
+      return;
+    }
     // Establish the operating point (and the clamped collar psi `used`) and leave
-    // the leaf outputs there for compute_rates' aux reads.
-    leaf.evaluate_root_collar_psi(tracked_root_psi_);
+    // the leaf outputs there for compute_rates' aux reads. Sharing the one
+    // prepare across all three calls also drops a redundant re-derivation of the
+    // soil-side caches per step (#530 did the same for the FD branch).
+    leaf.profit_at_collar_psi(tracked_root_psi_, bound_a, bound_b);
     const double used = -leaf.root_collar_psi_;
     dprofit_dpsi_ = leaf.dprofit_droot_collar_psi(used);
-    leaf.evaluate_root_collar_psi(used);  // restore operating-point outputs
+    leaf.profit_at_collar_psi(used, bound_a, bound_b);  // restore operating-point outputs
   } else {
     // Centred finite-difference fallback (#526), perturbing about the clamped
     // operating value `used`. A one-sided difference biases the fixed point to

--- a/tests/testthat/test-leaf.r
+++ b/tests/testthat/test-leaf.r
@@ -196,7 +196,14 @@ expect_error(l$set_physiology(area_leaf = area_leaf_, mass_root_prop = mass_root
   
   upper_bound_int <- 3*((log(1/1e-5))^(1/2.04))
   #for situations where psi_stem exceeds tolerance of integrator
-  expect_error(l$transpiration(upper_bound_int, psi_stem[1]), "Extrapolation disabled and evaluation point outside of interpolated domain.")
+  # The message used to be odelia's bare "Extrapolation disabled and evaluation
+  # point outside of interpolated domain.", which named neither the spline, the
+  # point nor the domain; #576 was localised by bisecting the four call sites by
+  # hand because of it. Assert the parts that make it a diagnosis.
+  expect_error(l$transpiration(upper_bound_int, psi_stem[1]),
+               "transpiration_from_psi")
+  expect_error(l$transpiration(upper_bound_int, psi_stem[1]),
+               "outside its domain")
   
   #for situations where psi_soil exceeds psi_crit + tolerance
   
@@ -204,8 +211,11 @@ expect_error(l$set_physiology(area_leaf = area_leaf_, mass_root_prop = mass_root
   l$set_physiology(area_leaf = area_leaf_, mass_root_prop = 1, rho = 608, a_bio = 0.0245, PPFD = PPFD, psi_soil = psi_soil, soil_depth = soil_depth, leaf_specific_conductance_max = leaf_specific_conductance_max, atm_vpd = atm_vpd, ca = ca, sapwood_volume_per_leaf_area = sapwood_volume_per_leaf_area, leaf_temp = leaf_temp_, atm_o2_kpa = atm_o2_kpa_, atm_kpa = atm_kpa_)
   psi_stem = psi_soil 
   
-  expect_error(l$transpiration(psi_stem[1], psi_soil[1]), "Extrapolation disabled and evaluation point outside of interpolated domain.")
-  
+  expect_error(l$transpiration(psi_stem[1], psi_soil[1]),
+               "transpiration_from_psi")
+  expect_error(l$transpiration(psi_stem[1], psi_soil[1]),
+               "outside its domain")
+
   #test that fast E supply calculation is closely approximating full integration
   psi_soil = 0
   l$set_physiology(area_leaf = area_leaf_, mass_root_prop = 1, rho = 608, a_bio = 0.0245, PPFD = PPFD, psi_soil = psi_soil, soil_depth = soil_depth, leaf_specific_conductance_max = leaf_specific_conductance_max, atm_vpd = atm_vpd, ca = ca, sapwood_volume_per_leaf_area = sapwood_volume_per_leaf_area, leaf_temp = leaf_temp_, atm_o2_kpa = atm_o2_kpa_, atm_kpa = atm_kpa_)

--- a/tests/testthat/test-tf24-arid-corner.R
+++ b/tests/testthat/test-tf24-arid-corner.R
@@ -17,8 +17,15 @@
 # psi_soil at which the setup calls themselves fail first
 # (find_root_psi throws "invalid f_ri" at psi_soil = 4 MPa, and
 # find_psi_stem_from_psi_root leaves the transport spline's domain above
-# ~3.7 MPa) -- brittleness worth its own issue, but not a place to anchor a
-# regression test.
+# ~3.7 MPa) -- brittleness worth its own issue, which became #576.
+#
+# #576 turned out NOT to be a too-narrow spline domain. TF24f's exact-gradient
+# path asked for an acclimation gradient in the hydraulic shut-down state, where
+# root_collar_psi_ is set to -root_psi_crit -- a collar potential at which soil
+# uptake is *negative*, so the stem potential carrying it would have to be wetter
+# than saturation and the transport inverse genuinely has no solution. The
+# out-of-domain error was correct; the question was wrong. See the tests at the
+# bottom of this file.
 
 test_that("a dry TF24f patch no longer aborts on the ci root-find", {
   # The reproducer that found it: 5 layers held below the residual floor with
@@ -176,4 +183,84 @@ test_that("a failed light spline reports the patch state that caused it", {
   # former, but assert that both counts are reported rather than pinning which.
   expect_match(msg, "between two cohorts of non-zero density")
   expect_match(msg, "nodes have zero density")
+})
+
+## ---------------------------------------------------------------------------
+## #576: the transport spline's domain, and who was asking
+## ---------------------------------------------------------------------------
+
+## The #576 reproducer: the dry start above, but at the narrow rainfall window
+## where TF24f died and TF24 did not. Rainfall 0 and 0.06 both ran, so this is a
+## knife-edge in the middle rather than "drier fails".
+tf24_dry_window <- function(model = "TF24f", rain = 0.05, lifetime = 10) {
+  env <- Environment(model)
+  env$set_soil_number_of_depths(5)
+  env$set_soil_water_state(rep(0.005, 5))
+  env$extrinsic_drivers_set_constant("rainfall", rain)
+
+  p <- scm_base_parameters(model)
+  p$max_patch_lifetime <- lifetime
+  p <- add_strategies(p, trait_matrix(0.0825, "lma"))
+  list(p = p, env = env)
+}
+
+test_that("TF24f completes in the dry rainfall window (#576)", {
+  # Both values failed with "Extrapolation disabled and evaluation point outside
+  # of interpolated domain", from psi_from_transpiration's LOWER end. The
+  # neighbours are included to keep the window itself under test: if a future
+  # change moves the knife-edge rather than removing it, the run that starts
+  # failing should be one of these.
+  for (rain in c(0.03, 0.04, 0.05, 0.06)) {
+    x <- tf24_dry_window(rain = rain)
+    expect_no_error(run_scm(x$p, x$env, collect = FALSE))
+  }
+})
+
+test_that("both TF24f gradient methods survive hydraulic shutdown (#576)", {
+  # The cause was an asymmetry, not a bad number. The finite-difference branch of
+  # TF24f_Strategy::solve_leaf checked prepare_collar_solve's return value and
+  # returned a zero gradient when the operating point had been forced by
+  # feasibility handling; the AD branch called evaluate_root_collar_psi (which
+  # hides that return value) and then asked for a gradient regardless. So the
+  # test that matters is that the two branches agree here, not that one number
+  # came out right.
+  for (ad in c(TRUE, FALSE)) {
+    x <- tf24_dry_window()
+    s <- x$p$strategies[[1]]
+    s$use_ad_gradient <- ad
+    x$p$strategies[[1]] <- s
+    expect_no_error(run_scm(x$p, x$env, collect = FALSE))
+  }
+})
+
+test_that("an out-of-domain transport lookup names the spline (#576)", {
+  # Naming the spline, the point and the domain is the whole diagnosis: odelia's
+  # own message is a bare sentence with none of the three, and #576 was localised
+  # by bisecting the four candidate call sites by hand. Driven on a bare Leaf
+  # because the SCM reproducer no longer reaches the state.
+  l <- Leaf(vcmax_25 = 96, jmax_25 = 157.44, c = 2.04, b = 3.457268,
+            psi_crit = 5.91988, root_c = 2.680147, root_b = 3.898245,
+            root_psi_crit = 5.870283, beta2 = 1.5, a = 0.3,
+            curv_fact_elec_trans = 0.7, curv_fact_colim = 0.99,
+            GSS_tol_abs = 1e-3, vulnerability_curve_ncontrol = 100,
+            ci_abs_tol = 1e-3, ci_niter = 1000, g1_TF24 = 7.5,
+            beta_R_H = 3.4e2, beta_R_V = 9.4e3)
+
+  msg <- tryCatch(l$transpiration(50, 0), error = conditionMessage)
+  expect_match(msg, "transpiration_from_psi", fixed = TRUE)
+  expect_match(msg, "psi_stem = 50", fixed = TRUE)
+  expect_match(msg, "beyond the upper end", fixed = TRUE)
+  # The domain, so the reader can see whether widening it would even help.
+  expect_match(msg, "\\[0, [0-9.]+\\]")
+  # And which call was asking, since the same spline is read from four places.
+  expect_match(msg, "in Leaf::transpiration", fixed = TRUE)
+
+  # A non-finite point must NOT be turned into a domain complaint. The guard uses
+  # the same comparison odelia does (`u < lo || u > hi`) rather than negating an
+  # in-range test, so NaN falls through to the spline as it always has and comes
+  # back as NA -- caught downstream by the isfinite(profit_) guards, which report
+  # the whole collar solve rather than one lookup. Negating an in-range test here
+  # would read as a tightening and is really a behaviour change: it breaks the
+  # documented profit_psi_stem_TF(NA, .) -> NA contract in test-leaf.r.
+  expect_true(is.na(l$transpiration(NaN, 0)))
 })


### PR DESCRIPTION
TF24f's two gradient methods disagreed. The FD branch checks what
`prepare_collar_solve()` returned and takes a zero gradient when the operating
point was forced by feasibility handling. The AD branch — the default — went
through `evaluate_root_collar_psi()`, which hides that return value, and asked
for a gradient at a collar potential the feasibility analysis had already
rejected. In shutdown that amounts to asking for a ψ_stem wetter than
saturation, which does not exist.

The AD branch now mirrors the FD branch. The spline error stays, neither clamped
nor widened: hydraulic shutdown is attainable and is represented as a zero
gradient, but a ψ_stem wetter than saturation is not attainable and has to fail.
The four throwing transport lookups now name the spline, the point, how far
outside it fell, the domain and the caller.

Behaviour changes only in states that previously threw, so the TF24f scientific
version does not move.

Closes #576.
