### PR TITLE
Keep PR descriptions out of git log

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Replace this text. Why the change was needed, then what changed in observable
+behaviour — two short paragraphs, under 20 lines. It becomes the squash commit
+message verbatim, so write it for someone reading `git log` in three years.
+
+Measurements, benchmark tables, suite counts, alternatives rejected, what you
+tried first, and stacking notes go in the **first comment** on this PR, not here:
+https://github.com/traitecoevo/plant-meta/blob/main/governance/commit-messages.md
+
+Closes #

--- a/agents.md
+++ b/agents.md
@@ -561,6 +561,11 @@ repo's README for how it renders, freezes (`_freeze/`), and version-pins posts.
 - ⚠️ Several hot-path constructs look "wrong" but are deliberate performance
   choices — see §12 before "tidying" them (inline helpers in headers, integer
   index constants, ratio-first signatures, scratch buffers).
+- ✅ Opening a PR → its title and body **become the squash commit message**, verbatim
+  and permanently. Subject ≤72 chars *including* the ` (#NNN)` GitHub appends, body
+  under 20 lines. Measurements, benchmark tables, suite counts, rejected alternatives,
+  disproved hypotheses and branch bookkeeping go in the **first PR comment** instead —
+  see [`commit-messages.md`](https://github.com/traitecoevo/plant-meta/blob/main/governance/commit-messages.md).
 
 ---
 
@@ -732,6 +737,10 @@ org — a hub-and-spoke set of packages built around the
   work is tracked on [board #5](https://github.com/orgs/traitecoevo/projects/5) (new issues
   auto-add with no Status = the triage queue). Labels: `bug` / `task` / `epic` plus `blocked`,
   `needs-info`, `cross-package`, `breaking`, `question`.
+- **Commit messages** — the repo squash-merges, so a PR's title and body are copied verbatim into
+  permanent history. Keep them short and durable and put the working detail in the first PR
+  comment; the split is set out in
+  [`commit-messages.md`](https://github.com/traitecoevo/plant-meta/blob/main/governance/commit-messages.md).
 - **What should run vs. what should fail** — strategies and environments are expected to run
   across a wide range of trait values and conditions and give sensible biological outputs
   (including zero growth or reproduction) rather than crash; a *physically unrealistic* state


### PR DESCRIPTION
The repo squash-merges, so a PR's title and body are copied verbatim into
permanent history — and bodies here have grown roughly tenfold in words
since 2026. Nothing recorded the rule, so nothing pushed back.

Adds the rule to the §11 conventions checklist and a pointer bullet to the
Plant family block, both deferring to the family guideline in `plant-meta`.
Adds a minimal `.github/PULL_REQUEST_TEMPLATE.md`: prose placeholders rather
than a commented-out questionnaire, because a PR body reaches the commit
message with its HTML comments intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
