### PR TITLE
Pin odelia to v0.2.1, matching phylloptim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,8 +53,8 @@ Suggests:
     kableExtra
 Remotes:
     richfitz/RcppR6,
-    traitecoevo/odelia@806924e,
-    traitecoevo/phylloptim@818ad43
+    traitecoevo/odelia@v0.2.1,
+    traitecoevo/phylloptim@e60a26af
 URL: https://github.com/traitecoevo/plant
 BugReports: https://github.com/traitecoevo/plant/issues
 Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
plant's develop cannot resolve its dependencies: phylloptim declared a
bare `Remotes: traitecoevo/odelia` while plant pinned a sha, so pak saw
two sources for one package and refused to solve. They agreed only until
odelia's master next moved, which it did.

odelia now carries a v0.2.1 tag and phylloptim names it too, so the two
specs are identical and cannot drift apart. The phylloptim pin moves to
e60a26af to pick that up; `inst/include/` is byte-identical across the
bump, so no results change.

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>