### PR TITLE
Assert what the hydraulic domain error diagnoses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -639,6 +639,8 @@ were not previously recorded here:
 
 ### Minor changes & bug fixes
 
+* **An out-of-domain hydraulic lookup now names the spline, the point, the domain and the caller** (#576), via odelia >= 0.2.2 and phylloptim >= 0.2.1, both already required. The message used to be odelia's bare "Extrapolation disabled and evaluation point outside of interpolated domain.", which named none of the four — and since the leaf reads the same transport spline from four places and holds a second spline that is its inverse, that sentence did not distinguish the cases that matter. Localising #576 meant instrumenting the call sites by hand to find out which spline was read and at what value; the answer (the *lower* end of the inverse, where the demanded flux is negative) is what showed the spline had been right to refuse. Error text only; no model behaviour changes. `test-leaf.r` now asserts the spline, which end was missed and the caller, rather than the whole sentence — which is phylloptim's to word.
+
 * **The scenario gateway scores numerical viability and persistence as separate
   axes, and no longer leads with a match rate** (#572). `scenario_summary()`
   classified a run as a success on `finite && total > 0`; with `birth_rate = 1`

--- a/tests/testthat/test-leaf.r
+++ b/tests/testthat/test-leaf.r
@@ -235,16 +235,34 @@ expect_error(l$set_physiology(root_network = net(rep((root_carbon_) / area_leaf_
   
   upper_bound_int <- 3*((log(1/1e-5))^(1/2.04))
   #for situations where psi_stem exceeds tolerance of integrator
-  expect_error(l$transpiration(upper_bound_int, psi_stem[1]), "evaluated outside its domain")
-  
+  # The leaf reads the same transport spline from four places and holds a second
+  # spline that is its inverse, so "outside its domain" on its own does not say
+  # which lookup failed -- and that is the fact localising #576 turned on. Assert
+  # the three parts that make the message a diagnosis (which spline, which end,
+  # which caller) rather than the whole sentence, which is phylloptim's to word.
+  err <- expect_error(l$transpiration(upper_bound_int, psi_stem[1]),
+                      "evaluated outside its domain")
+  expect_match(conditionMessage(err), "transpiration_from_psi")
+  expect_match(conditionMessage(err), "beyond the upper end")
+  expect_match(conditionMessage(err), "Leaf::transpiration, at psi_stem")
+
   #for situations where psi_soil exceeds psi_crit + tolerance
   
   psi_soil = upper_bound_int
   l$set_physiology(root_network = net((1) / area_leaf_, soil_depth), PPFD = PPFD, psi_soil = psi_soil, soil_depth = soil_depth, leaf_specific_conductance_max = leaf_specific_conductance_max, atm_vpd = atm_vpd, ca = ca, leaf_temp = leaf_temp_, atm_o2_kpa = atm_o2_kpa_, atm_kpa = atm_kpa_)
   psi_stem = psi_soil 
   
-  expect_error(l$transpiration(psi_stem[1], psi_soil[1]), "evaluated outside its domain")
-  
+  # Same spline, same end -- and the SAME caller label, because psi_stem and
+  # psi_soil are equal here and `Leaf::transpiration` checks the stem argument
+  # first, so it never reaches the upstream one. Asserted rather than left
+  # implicit: this case is reached from the soil side, and the label saying
+  # `at psi_stem` is the thing that would otherwise read as a bug.
+  err <- expect_error(l$transpiration(psi_stem[1], psi_soil[1]),
+                      "evaluated outside its domain")
+  expect_match(conditionMessage(err), "transpiration_from_psi")
+  expect_match(conditionMessage(err), "beyond the upper end")
+  expect_match(conditionMessage(err), "Leaf::transpiration, at psi_stem")
+
   #test that fast E supply calculation is closely approximating full integration
   psi_soil = 0
   l$set_physiology(root_network = net((1) / area_leaf_, soil_depth), PPFD = PPFD, psi_soil = psi_soil, soil_depth = soil_depth, leaf_specific_conductance_max = leaf_specific_conductance_max, atm_vpd = atm_vpd, ca = ca, leaf_temp = leaf_temp_, atm_o2_kpa = atm_o2_kpa_, atm_kpa = atm_kpa_)


### PR DESCRIPTION
`test-leaf.r` asserted only "evaluated outside its domain", which does not say which lookup failed -- and that is the fact worth pinning. The leaf reads the same transport spline from four places and holds a second that is its inverse, so what a caller needs from the message is which of those it was.

Both assertions now check the spline, which end was missed and the caller. The soil-side case names the **stem** argument, because `psi_stem` and `psi_soil` are equal there and the stem check comes first. NEWS records the message (#576) under Minor changes.

Test text only; no model behaviour moves. Rebased onto `develop`: the original DESCRIPTION hunk is obsolete, #633 having already taken plant to phylloptim 0.6.0 / odelia 0.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
