### PR TITLE
Report leaf temperature as a TF24 aux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -437,8 +437,44 @@ were not previously recorded here:
   * Semantic change: `patch$ode_rates` was a cheap read of stored values and is
     now a full right-hand-side evaluation. `StochasticPatch$compute_rates()` is
     unchanged.
+* TF24/TF24f gain a `Tleaf` auxiliary variable, so their `aux_size` grows by one
+  (#625; see New features for what the slot holds). Additive — it is appended
+  after `assimilation` — so every existing name lookup and every positional index
+  below it is unchanged. Migration, for code that indexes auxs by position or
+  asserts their count:
+  * `aux_size` `12` -> `13`; with `collect_all_auxiliary`, `13` -> `14`
+  * `auxs[[13]]` (`area_sapwood`, `collect_all_auxiliary` only) -> `auxs[[14]]`,
+    or better `ind$aux("area_sapwood")`
+  * no other slot moves; `ind$aux(<name>)` needs no change anywhere
 
 ### New features
+
+* **TF24 and TF24f report leaf temperature as an auxiliary variable, `Tleaf`
+  (#625).** The leaf's own temperature at the optimal operating point, in deg C,
+  alongside `opt_psi_stem` and the other leaf outputs. `aux_size` therefore goes
+  12 -> 13 (13 -> 14 with `collect_all_auxiliary`), appended after
+  `assimilation`, so existing positional indices are unchanged except
+  `area_sapwood`, which moves from 13 to 14.
+
+  It is an **output, not the `leaf_temp` driver**, and that is the whole reason
+  for the slot. With `pars$use_energy_balance` at its default of `0` the leaf
+  runs at the prescribed driver and `Tleaf` equals it exactly — reported anyway,
+  rather than `NA`, so the column can be plotted against anything. Turn the
+  Penman-Monteith energy balance on and the leaf solves its own temperature from
+  its transpiration at every operating point; that value was computed, used to
+  re-derive the whole Farquhar temperature block, and then discarded, so the one
+  quantity the PM path exists to produce was the one a canopy-level analysis
+  could not read. Measured on a 5 m plant at PPFD 1800 with air at 30 °C, the
+  leaf sits at **39.2 °C**.
+
+  Under `shading_model = "deep-crown"` it is integrated to the leaf-area-weighted
+  crown mean alongside `profit`, `transpiration`, `assimilation` and the rest,
+  and NOT left at whichever quadrature node the crown loop ended on. Note what
+  that means for interpretation: it is a **crown mean**, not any single leaf's
+  temperature, so a canopy with a hot top and a cool base reports the average of
+  the two. The depth profile itself is not exposed — a fixed-width aux slot
+  cannot carry a per-node vector — so the second half of #625 (reporting each
+  leaf output against crown depth) remains open.
 
 * **The NSC storage pool is bounded by the shape of its own flow (`TF24@v9`,
   `TF24f@v9.1`).** `dS/dt` was `net_flux > 0 ? net_flux : floor_gate * net_flux`

--- a/R/TF24_plot_diagnostics.R
+++ b/R/TF24_plot_diagnostics.R
@@ -3,7 +3,12 @@
 #' Assembles a multi-panel diagnostic figure from a collected TF24 SCM run:
 #' patch leaf area, the size distribution, soil water potential, stem and root
 #' water potentials, profit, stomatal conductance, transpiration (total and per
-#' leaf area) and the rainfall driver. Panels are combined with `patchwork`.
+#' leaf area), the rainfall driver and leaf temperature. Panels are combined
+#' with `patchwork`.
+#'
+#' The leaf-temperature panel is flat at the prescribed `leaf_temp` driver
+#' unless the strategy ran with `pars$use_energy_balance` non-zero; see the
+#' `Tleaf` auxiliary variable.
 #'
 #' `ggplot2` and `patchwork` are Suggested packages; the function errors if
 #' either is unavailable. The returned plot is neither drawn nor saved — print
@@ -119,6 +124,19 @@ TF24_plot_diagnostics <- function(results, x, y) {
     ggplot2::xlab("Time (years)") +
     ggplot2::labs(colour = "Height (m)") -> stomatal_conductance
 
+  # Leaf temperature by height over time. Flat at the prescribed driver unless
+  # the strategy ran with pars$use_energy_balance non-zero, in which case it is
+  # the leaf's own solved temperature -- and under the deep-crown shading model,
+  # the leaf-area-weighted crown mean of it rather than any single leaf's.
+  results$species %>%
+    ggplot2::ggplot(ggplot2::aes(x = .data$time, y = .data$Tleaf)) +
+    ggplot2::geom_line(ggplot2::aes(colour = .data$height, group = .data$node), na.rm = TRUE) +
+    ggplot2::theme_bw() +
+    ggplot2::theme(text = ggplot2::element_text(size = 20)) +
+    ggplot2::ylab(expression(paste(T[leaf], " (", degree, C, ")"))) +
+    ggplot2::xlab("Time (years)") +
+    ggplot2::labs(colour = "Height (m)") -> leaf_temperature
+
   # Rainfall time series
   tibble::tibble(x = x, y = y) %>%
     ggplot2::ggplot(ggplot2::aes(x = .data$x, y = .data$y)) +
@@ -167,7 +185,8 @@ TF24_plot_diagnostics <- function(results, x, y) {
   combined <- (patch_leaf_area + size_distribution) /
     ((soil_water_potential + root_water_potential) / (stem_water_potential + profit)) /
     (stomatal_conductance + transpiration) /
-    (transpiration_per_leaf_area + rainfall)
+    (transpiration_per_leaf_area + rainfall) /
+    leaf_temperature
 
   combined
 }

--- a/inst/include/plant/models/tf24_strategy.h
+++ b/inst/include/plant/models/tf24_strategy.h
@@ -337,7 +337,24 @@ public:
       // area (umol CO2 m^-2 s^-1). Net, not gross: Leaf::assim_colimited()
       // subtracts dark respiration R_d_, so gross = assimilation + R_d_ with
       // R_d_ = 0.015 * vcmax_ at the acclimated vcmax_.
-      "assimilation"
+      "assimilation",
+      // Leaf temperature at the optimal operating point (deg C) -- an OUTPUT,
+      // not the `leaf_temp` driver, and the distinction is the point of
+      // reporting it. With pars.use_energy_balance off this equals the driver,
+      // so the column is flat at TF24's defaults; with it on the leaf solves
+      // its own temperature from its transpiration per operating point, and
+      // that value was previously computed, used to re-derive the whole
+      // Farquhar block, and then discarded -- so the one quantity the
+      // Penman-Monteith path exists to produce was the one a canopy-level
+      // analysis could not read (#625). Reported here rather than left to be
+      // inferred from an assimilation that cannot be explained without it.
+      //
+      // Under the deep-crown shading model this is the leaf-area-weighted crown
+      // mean, integrated alongside the other leaf outputs; it is NOT the
+      // temperature of any single leaf, and a canopy with a hot top and a cool
+      // base reports the mean of the two. The depth profile itself is not an
+      // aux (a fixed-width slot cannot carry a per-quadrature-node vector).
+      "Tleaf"
     });
     // add the associated computation to compute_rates and compute there
     if (collect_all_auxiliary) {
@@ -606,6 +623,7 @@ public:
   int aux_idx_shadow_cost = -1;
   int aux_idx_stom_cond_CO2 = -1;
   int aux_idx_assimilation = -1;
+  int aux_idx_Tleaf = -1;
   int aux_idx_area_sapwood = -1;       // only present when collect_all_auxiliary
   int state_idx_area_heartwood = -1;
   int state_idx_mass_heartwood = -1;

--- a/man/TF24_plot_diagnostics.Rd
+++ b/man/TF24_plot_diagnostics.Rd
@@ -23,9 +23,14 @@ The assembled `patchwork` plot.
 Assembles a multi-panel diagnostic figure from a collected TF24 SCM run:
 patch leaf area, the size distribution, soil water potential, stem and root
 water potentials, profit, stomatal conductance, transpiration (total and per
-leaf area) and the rainfall driver. Panels are combined with `patchwork`.
+leaf area), the rainfall driver and leaf temperature. Panels are combined
+with `patchwork`.
 }
 \details{
+The leaf-temperature panel is flat at the prescribed `leaf_temp` driver
+unless the strategy ran with `pars$use_energy_balance` non-zero; see the
+`Tleaf` auxiliary variable.
+
 `ggplot2` and `patchwork` are Suggested packages; the function errors if
 either is unavailable. The returned plot is neither drawn nor saved — print
 it or pass it to [ggplot2::ggsave()] as needed.

--- a/src/tf24_strategy.cpp
+++ b/src/tf24_strategy.cpp
@@ -74,6 +74,7 @@ void TF24_Strategy::refresh_indices () {
   aux_idx_shadow_cost           = aux_index.at("shadow_cost");
   aux_idx_stom_cond_CO2         = aux_index.at("stom_cond_CO2");
   aux_idx_assimilation          = aux_index.at("assimilation");
+  aux_idx_Tleaf                 = aux_index.at("Tleaf");
   // area_sapwood is only registered when collect_all_auxiliary is set.
   aux_idx_area_sapwood = aux_index.count("area_sapwood") ? aux_index.at("area_sapwood") : -1;
   state_idx_area_heartwood      = state_index.at("area_heartwood");
@@ -175,6 +176,10 @@ void TF24_Strategy::compute_rates(const TF24_Environment& environment,  Internal
   vars.set_aux(aux_idx_shadow_cost, leaf.shadow_cost());
   vars.set_aux(aux_idx_stom_cond_CO2, leaf.stom_cond_CO2_);
   vars.set_aux(aux_idx_assimilation, leaf.assim_colimited_);
+  // The leaf's own temperature at the operating point, not the `leaf_temp`
+  // driver -- see aux_names(). Equal to the driver while pars.use_energy_balance
+  // is off; solved from the leaf's transpiration when it is on.
+  vars.set_aux(aux_idx_Tleaf, leaf.Tleaf_);
 
 
 
@@ -544,7 +549,7 @@ double TF24_Strategy::net_mass_production_dt(const TF24_Environment& environment
       function_integrator.integrate_vector_x(0.0, height);
     const size_t nn = nodes.size();
     std::vector<double> profit_y(nn), trans_y(nn), eup_y(nn), psi_y(nn),
-      root_psi_y(nn), gco2_y(nn), assim_y(nn);
+      root_psi_y(nn), gco2_y(nn), assim_y(nn), tleaf_y(nn);
     std::vector<std::vector<double>> soil_y(
       soil_number_of_depths_, std::vector<double>(nn));
     for (size_t i = 0; i < nn; ++i) {
@@ -557,6 +562,11 @@ double TF24_Strategy::net_mass_production_dt(const TF24_Environment& environment
       root_psi_y[i] = leaf.opt_root_psi_ * qi;
       gco2_y[i]     = leaf.stom_cond_CO2_ * qi;
       assim_y[i]    = leaf.assim_colimited_ * qi;
+      // Leaf temperature varies through the crown because the light does, so it
+      // must be integrated like every other leaf output. Left out, `Tleaf_`
+      // would report whichever node the loop happened to end on -- and that node
+      // is neither the crown top nor the centre.
+      tleaf_y[i]    = leaf.Tleaf_ * qi;
       for (int a = 0; a < soil_number_of_depths_; ++a) {
         soil_y[a][i] = leaf.soil_consumption_[a] * qi;
       }
@@ -572,6 +582,7 @@ double TF24_Strategy::net_mass_production_dt(const TF24_Environment& environment
     leaf.opt_root_psi_    = function_integrator.integrate_vector(root_psi_y, 0.0, height);
     leaf.stom_cond_CO2_   = function_integrator.integrate_vector(gco2_y, 0.0, height);
     leaf.assim_colimited_ = function_integrator.integrate_vector(assim_y, 0.0, height);
+    leaf.Tleaf_           = function_integrator.integrate_vector(tleaf_y, 0.0, height);
     for (int a = 0; a < soil_number_of_depths_; ++a) {
       leaf.soil_consumption_[a] =
         function_integrator.integrate_vector(soil_y[a], 0.0, height);

--- a/tests/testthat/test-strategy-tf24.R
+++ b/tests/testthat/test-strategy-tf24.R
@@ -89,8 +89,8 @@ test_that("TF24 collect_all_auxiliary option", {
 
   s <- TF24_Strategy()
   p <- TF24_Individual(s)
-  expect_equal(p$aux_size, 12)
-  expect_equal(length(p$internals$auxs), 12)
+  expect_equal(p$aux_size, 13)
+  expect_equal(length(p$internals$auxs), 13)
 expect_equal(p$aux_names, c(
     "competition_effect",
     "height_inverse",
@@ -103,14 +103,15 @@ expect_equal(p$aux_names, c(
     "profit",
     "shadow_cost",
     "stom_cond_CO2",
-    "assimilation"
+    "assimilation",
+    "Tleaf"
   ))
 
   s <- TF24_Strategy(collect_all_auxiliary=TRUE)
   expect_true(s$collect_all_auxiliary)
   p <- TF24_Individual(s)
-  expect_equal(p$aux_size, 13)
-  expect_equal(length(p$internals$auxs), 13)
+  expect_equal(p$aux_size, 14)
+  expect_equal(length(p$internals$auxs), 14)
   expect_equal(p$aux_names, c(
     "competition_effect",
     "height_inverse",
@@ -124,6 +125,7 @@ expect_equal(p$aux_names, c(
     "shadow_cost",
     "stom_cond_CO2",
     "assimilation",
+    "Tleaf",
     "area_sapwood"
   ))
 })

--- a/tests/testthat/test-strategy-tf24f.R
+++ b/tests/testthat/test-strategy-tf24f.R
@@ -108,8 +108,8 @@ test_that("TF24f collect_all_auxiliary option", {
 
   s <- TF24f_Strategy()
   p <- TF24f_Individual(s)
-  expect_equal(p$aux_size, 12)
-  expect_equal(length(p$internals$auxs), 12)
+  expect_equal(p$aux_size, 13)
+  expect_equal(length(p$internals$auxs), 13)
 expect_equal(p$aux_names, c(
     "competition_effect",
     "height_inverse",
@@ -122,14 +122,15 @@ expect_equal(p$aux_names, c(
     "profit",
     "shadow_cost",
     "stom_cond_CO2",
-    "assimilation"
+    "assimilation",
+    "Tleaf"
   ))
 
   s <- TF24f_Strategy(collect_all_auxiliary=TRUE)
   expect_true(s$collect_all_auxiliary)
   p <- TF24f_Individual(s)
-  expect_equal(p$aux_size, 13)
-  expect_equal(length(p$internals$auxs), 13)
+  expect_equal(p$aux_size, 14)
+  expect_equal(length(p$internals$auxs), 14)
   expect_equal(p$aux_names, c(
     "competition_effect",
     "height_inverse",
@@ -143,6 +144,7 @@ expect_equal(p$aux_names, c(
     "shadow_cost",
     "stom_cond_CO2",
     "assimilation",
+    "Tleaf",
     "area_sapwood"
   ))
 })

--- a/tests/testthat/test-tf24-leaf-temp-aux.R
+++ b/tests/testthat/test-tf24-leaf-temp-aux.R
@@ -1,0 +1,170 @@
+# The `Tleaf` auxiliary variable (#625).
+#
+# phylloptim's Leaf carries the leaf's own temperature at the operating point as
+# an OUTPUT (`Tleaf_`), distinct from the `leaf_temp` driver it is handed. TF24
+# computed it, used it to re-derive the whole Farquhar temperature block, and
+# then discarded it -- so a canopy-level analysis could see the assimilation the
+# temperature produced but not the temperature itself. These tests pin the aux
+# slot's content, its units, and its behaviour under each shading model.
+#
+# Units: deg C.
+#
+# The distinction the slot exists for only becomes visible with
+# pars$use_energy_balance non-zero. With it off (TF24's default) the leaf runs at
+# the prescribed driver, and `Tleaf` is that driver exactly -- reported anyway,
+# rather than NA, so the column can be plotted against anything.
+
+tf24_temp_aux <- function(strategy = TF24_Strategy(), height = 5, ppfd = 1800,
+                          theta = rep(0.25, 5), leaf_temp = NULL,
+                          light = NULL) {
+  ind <- TF24_Individual(strategy)
+  ind$set_state("height", height)
+  env <- TF24_Environment()
+  env$extrinsic_drivers_set_constant("PPFD", ppfd)
+  if (!is.null(leaf_temp)) {
+    env$extrinsic_drivers_set_constant("leaf_temp", leaf_temp)
+  }
+  # `light` is canopy openness: a scalar for a uniform environment, or a
+  # function of height for a vertical gradient (which is the only way the three
+  # shading models can disagree -- see the deep-crown test below).
+  if (is.function(light)) {
+    hh <- seq(0, height, length.out = 101)
+    ip <- Interpolator()
+    ip$init(hh, vapply(hh, light, numeric(1)))
+    env$light_availability$spline <- ip
+  } else if (!is.null(light)) {
+    env$set_fixed_environment(light, height_max = height)
+  }
+  env$set_soil_number_of_depths(length(theta))
+  env$set_soil_water_state(theta)
+  ind$compute_rates(env)
+  stats::setNames(ind$internals$auxs, ind$aux_names)
+}
+
+pm_strategy <- function() {
+  s <- TF24_Strategy()
+  s$pars$use_energy_balance <- 1
+  s
+}
+
+test_that("Tleaf aux is written, not left unset", {
+  aux <- tf24_temp_aux()
+  expect_true("Tleaf" %in% names(aux))
+  expect_true(is.finite(aux[["Tleaf"]]))
+})
+
+test_that("with the energy balance off, Tleaf is the prescribed driver", {
+  # Not a tautology worth skipping: it is the assertion that the slot tracks the
+  # temperature the leaf actually ran at, and it is the only branch where the
+  # expected value is known exactly.
+  for (temp in c(15, 25, 35)) {
+    aux <- tf24_temp_aux(leaf_temp = temp)
+    expect_equal(aux[["Tleaf"]], temp, tolerance = 1e-12,
+                 info = paste("leaf_temp =", temp))
+  }
+})
+
+test_that("with the energy balance on, Tleaf departs from air temperature", {
+  # The driver is reinterpreted as AIR temperature on this path, and a bright,
+  # well-watered leaf sits above it. This is what the aux exists to report: off
+  # the PM path the two are equal by construction, so a test that only ran with
+  # the balance off could not distinguish an output from an echo of the input.
+  air <- 30
+  hot <- tf24_temp_aux(strategy = pm_strategy(), ppfd = 1800, leaf_temp = air)
+  expect_true(is.finite(hot[["Tleaf"]]))
+  expect_gt(hot[["Tleaf"]], air)
+
+  # ...and a dark leaf is not warmed by radiation it does not absorb, so it sits
+  # at or below air temperature. The pair brackets the driver, which is the
+  # property that would fail if the slot were echoing `leaf_temp`.
+  dark <- tf24_temp_aux(strategy = pm_strategy(), ppfd = 0, leaf_temp = air)
+  expect_lte(dark[["Tleaf"]], hot[["Tleaf"]])
+  expect_gt(hot[["Tleaf"]] - dark[["Tleaf"]], 1)
+})
+
+test_that("Tleaf rises with absorbed radiation under the energy balance", {
+  by_light <- vapply(c(0, 200, 800, 1800),
+                     function(q) tf24_temp_aux(strategy = pm_strategy(),
+                                               ppfd = q)[["Tleaf"]],
+                     numeric(1))
+  expect_true(all(is.finite(by_light)))
+  expect_true(all(diff(by_light) > 0))
+})
+
+test_that("Tleaf is finite when the hydraulic solve shuts down", {
+  # Both shut-down exits bypass the transpiring branch, so they seat Tleaf at the
+  # zero-transpiration (hottest) temperature explicitly. Dry top layers over wet
+  # deep ones drives the shutdown; the same driver as the assimilation-aux test.
+  dry <- c(rep(0.04, 8), rep(0.35, 7))
+  aux <- tf24_temp_aux(theta = dry)
+  expect_true(is.finite(aux[["Tleaf"]]))
+
+  pm <- tf24_temp_aux(strategy = pm_strategy(), theta = dry, leaf_temp = 30)
+  expect_true(is.finite(pm[["Tleaf"]]))
+  # No latent cooling at zero transpiration, so the shut-down leaf is warmer than
+  # air rather than pinned to it.
+  expect_gt(pm[["Tleaf"]], 30)
+})
+
+test_that("Tleaf is reported under every shading model", {
+  # Deep-crown must integrate Tleaf to a leaf-area-weighted crown mean alongside
+  # the other leaf outputs. Left out of that loop it would report whichever
+  # quadrature node the loop ended on -- finite, plausible, and wrong.
+  for (model in c("mean-light", "crown-centre", "deep-crown")) {
+    s <- pm_strategy()
+    s$control$shading_model <- model
+    aux <- tf24_temp_aux(strategy = s, leaf_temp = 30)
+    expect_true(is.finite(aux[["Tleaf"]]), info = model)
+    expect_gt(aux[["Tleaf"]], 30)
+  }
+})
+
+test_that("deep-crown Tleaf is a crown mean over the light gradient", {
+  # Under a UNIFORM light environment every quadrature node sees the same light,
+  # so all three models agree exactly and this test could not tell an integral
+  # from a single node. The gradient is what makes the assertion mean something:
+  # a stand-alone Individual sits in no patch, so it is imposed directly on the
+  # environment's light spline.
+  h <- 15
+  light <- function(z) 0.08 + 0.9 * (z / h)^2   # dark base, bright top
+  make <- function(model, ...) {
+    s <- pm_strategy()
+    s$control$shading_model <- model
+    tf24_temp_aux(strategy = s, height = h, leaf_temp = 30, ...)[["Tleaf"]]
+  }
+
+  deep <- make("deep-crown", light = light)
+  # The coolest and warmest leaves in the crown: the same plant under uniform
+  # light equal to the crown base's and the crown top's. A leaf-area-weighted
+  # mean of the profile must sit strictly inside that bracket -- which is exactly
+  # what leaving Tleaf at one quadrature node would not guarantee.
+  base <- make("deep-crown", light = light(0))
+  top <- make("deep-crown", light = light(h))
+  expect_true(all(is.finite(c(deep, base, top))))
+  expect_gt(top, base)
+  expect_gt(deep, base)
+  expect_lt(deep, top)
+
+  # ...and the gradient makes the three shading models genuinely disagree, so a
+  # deep-crown value equal to either single-evaluation model to the last digit
+  # would mean the integral had collapsed onto one node.
+  expect_false(isTRUE(all.equal(deep, make("crown-centre", light = light),
+                                tolerance = 1e-10)))
+  expect_false(isTRUE(all.equal(deep, make("mean-light", light = light),
+                                tolerance = 1e-10)))
+})
+
+test_that("under uniform light every shading model gives the same Tleaf", {
+  # The counterpart of the test above, and the property that pins the weighting:
+  # q integrates to one over the crown, so the deep-crown integral of a constant
+  # is that constant. An un-normalised sum would not be.
+  make <- function(model) {
+    s <- pm_strategy()
+    s$control$shading_model <- model
+    tf24_temp_aux(strategy = s, height = 15, leaf_temp = 30,
+                  light = 0.4)[["Tleaf"]]
+  }
+  ref <- make("deep-crown")
+  expect_equal(make("crown-centre"), ref, tolerance = 1e-10)
+  expect_equal(make("mean-light"), ref, tolerance = 1e-10)
+})

--- a/tests/testthat/test-tf24-plot-diagnostics.R
+++ b/tests/testthat/test-tf24-plot-diagnostics.R
@@ -20,6 +20,12 @@ test_that("TF24_plot_diagnostics assembles a TF24 stand diagnostic figure", {
 
   results <- run_scm(p1, env = env, ctrl = ctrl, collect = TRUE)
 
+  # Every aux the figure plots must have reached the collected per-node table.
+  # ggplot's aes() is lazy, so a missing column would not error until the plot
+  # were drawn -- which this test does not do. Check the columns directly.
+  expect_true(all(c("opt_psi_stem", "opt_root_psi", "profit", "stom_cond_CO2",
+                    "Tleaf") %in% names(results$species)))
+
   p <- TF24_plot_diagnostics(results, x, y)
 
   expect_s3_class(p, "patchwork")


### PR DESCRIPTION
Adds a `Tleaf` auxiliary variable to TF24/TF24f: the leaf's own temperature at the optimal operating point, not the `leaf_temp` driver. Integrated to the leaf-area-weighted crown mean under the deep-crown shading model, and plotted in `TF24_plot_diagnostics()`.

`aux_size` goes 12 -> 13, appended after `assimilation`, so no name lookup and no positional index below it moves.

Closes #625's first half; the crown-depth profile is left open — see the comment.
